### PR TITLE
Initial version of the projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the ODPi Egeria project.
+#
+# Link to help info - https://git-scm.com/docs/gitignore
+#
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Maven
+target*
+dependency-reduced-pom.xml
+core*.dmp
+pom.xml.releaseBackup
+
+# IntelliJ
+*.iml
+**.iml
+*.ipr
+*.iws
+.idea
+venv
+
+# Eclipse
+.cache
+.classpath
+.project
+.checkstyle
+
+.settings
+.externalToolBuilders
+maven-eclipse.xml
+
+#Python
+*.pyc
+
+# review board
+.reviewboardrc
+
+# Scala-IDE specific
+.cache-main
+.cache-tests
+
+# emacs files
+*#
+*~
+
+# Mac OS
+__MACOSX
+
+# specific Egeria config files
+omag.server.*.config
+omag.server.*.auditlog/**
+*.registrystore
+keystore_*/**
+
+# Conformance Test Suite results for Egeria
+*.testlab.results
+openmetadata_cts_summary.json
+profile-details/*.json
+test-case-details/*.json
+
+# Dynamic data used by egeria
+data/**
+
+# other files
+.DS_Store
+*.swp
+.java-version
+*.graphml
+
+# Ignore Lineage repository
+egeria-lineage-repositories/**
+
+# Ignore local graph repo
+*-graph-repository/**
+
+# Ignore archives if they are in the top level directory
+/CloudInformationModel.json
+/DataStoreConnectorTypes.json
+/OpenMetadataTypes.json
+/SimpleAPICatalog.json
+/SimpleDataCatalog.json
+/SimpleEventCatalog.json
+/SimpleGovernanceCatalog.json
+/*Archive.json
+
+# Ignore reports
+/*report.md
+
+# Ignore any json files generated during junit
+open-metadata-resources/open-metadata-archives/design-model-archives/*.json
+
+# Ignore Subject Area OMAS older Generated output so it is not checked in.
+open-metadata-implementation/access-services/subject-area/subject-area-server/src/main/java/org/odpi/openmetadata/accessservices/subjectarea/generated/**
+open-metadata-implementation/access-services/subject-area/subject-area-server/src/test/java/org/odpi/openmetadata/accessservices/subjectarea/generated/**
+
+# Ignore fvt Generated output
+open-metadata-test/open-metadata-fvt/open-types-fvt/open-types-test/src/**
+
+# Ignore Deployment / Samples Generated content
+open-metadata-resources/open-metadata-deployment/sample-data/coco-pharmaceuticals/cache/**
+open-metadata-resources/open-metadata-deployment/sample-data/coco-pharmaceuticals/*.retry
+open-metadata-resources/open-metadata-deployment/sample-data/coco-pharmaceuticals/metadata/ibm-igc/generated_*
+
+# Ignore UI downloaded components
+open-metadata-implementation/user-interfaces/ui-chassis/ui-chassis-spring/src/main/resources/public/**
+open-metadata-implementation/user-interfaces/ui-chassis/ui-chassis-spring/tools/**
+open-metadata-implementation/user-interfaces/ui-chassis/ui-chassis-spring/src/main/static/node_modules/**
+open-metadata-implementation/user-interfaces/ui-chassis/ui-chassis-spring/src/main/static/package-lock.json
+
+# Ignore private maven repo (jenkins)
+.repository
+
+# exclude temporary lock files
+*.lock
+log
+# m2 repo used by linux foundation build
+**/m2repo*/**
+
+# ignore github pages build file and site.
+Gemfile
+
+# vscode editor
+**/.vscode*/**
+**/.factorypath
+**/**.code-workspace
+
+# Jupyter notebook temp/update files
+**/.ipynb_checkpoints
+
+# Java core files
+Snap*.trc
+javacore*.txt
+jitdump*dmp
+
+# License files (generated)
+THIRD_PARTY*.txt
+
+# gradle
+!gradle/**
+.gradle/
+build/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # egeria-dev-projects
-Fun projects a developer can do with Egeria
+
+Fun projects a developer can do with Egeria.  Each module has working code that you can use "as is" or you
+may extend it for your own uses.
+
+* **component-id-report** - list the component ids in use in your Egeria deployment.  
+  these component ids are used when registering with the audit log and are included in
+  each audit log message from the component.  Using unique component ids helps to pinpoint
+  exactly which component produced a specific audit log record.
+  
+  Code starts with the components that are shipped with Egeria.  Update to include your
+  connector implementation.
+  
+* **egeria-config-utility** - issues commands to configure different types of OMAG servers.
+  It has a list of default values at the top of the file and that you can update for your environment
+  and you can extend with new commands and options.
+
+* **egeria-ops-utility** - issues commands to start and stop different types of OMAG servers.
+  It has a list of default values at the top of the file and that you can update for your environment
+  and you can extend with new commands and options.
+  
+* **egeria-platform-report** - issue commands to a running platform an reports on the status of
+  the platform itself and the servers running on it.  There are different options that control the
+  detail displayed.  Extend it with new options and layouts.
+  
+* **event-display-audit-log-connector** - an implementation of an Audit Log Destination Connector
+  that displays the contents of event added ans additionalInformation in EVENT audit log record.
+  Change the format or add additional information.
+  
+* **kafka-topics-capture-connector** - an implementation of an Integration Connector that catalogs the
+  topics that are known to an Apache Kafka server.
+
+* **asset-look-up** - a report about the metadata associated with an Asset entity.  Use **asset-set-up**
+  to populate your metadata repository and then explore ...
+  
+* **asset-set-up** - a utility to populate a metadata access store with a variety of
+  metadata centred around an Asset.  This is a metadata element describing a digital
+  resource.
+  
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/asset-look-up/README.md
+++ b/asset-look-up/README.md
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+
+# The Egeria Config Utility (egeria-config-utility)
+
+The Egeria config utility creates configuration documents for OMAG servers.  It has two modes
+of operation:
+
+* *Interactive* - the utility loops waiting for more commands.  It is designed to run
+  IntelliJ (or similar IDE) where it is available for new commands as you work with Egeria.
+  
+* *Command* - the utility takes parameters to describe the server and it is configured in a
+  single request.
+
+This utility works from a set of hard-coded defaults that you can change for your environment.  
+There is also plenty of scope to add new options to configure different types of servers and
+features.
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the Egeria project.

--- a/asset-look-up/pom.xml
+++ b/asset-look-up/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>egeria-dev-projects</artifactId>
+        <groupId>org.odpi.egeria</groupId>
+        <version>3.6-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Asset Look Up</name>
+    <description>
+        Issues requests to retrieve assets and display all the metadata known about it.
+    </description>
+
+    <artifactId>asset-look-up</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>asset-consumer-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>http-helper</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/asset-look-up/src/main/java/org/odpi/openmetadata/devprojects/reports/assetlookup/AssetLookUp.java
+++ b/asset-look-up/src/main/java/org/odpi/openmetadata/devprojects/reports/assetlookup/AssetLookUp.java
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.reports.assetlookup;
+
+import org.odpi.openmetadata.accessservices.assetconsumer.client.AssetConsumer;
+import org.odpi.openmetadata.frameworks.connectors.properties.AssetUniverse;
+import org.odpi.openmetadata.http.HttpHelper;
+
+
+/**
+ * AssetLookUp illustrates the use of the Asset Consumer OMAS API to search for and
+ * display the metadata linked to an Asset.
+ */
+public class AssetLookUp
+{
+    private String  serverName;
+    private String  serverURLRoot;
+    private String  clientUserId;
+
+    private AssetConsumer client = null;
+
+    /**
+     * Set up the parameters for the sample.
+     *
+     * @param serverName server to call
+     * @param serverURLRoot location of server
+     * @param clientUserId userId to access the server
+     */
+    public AssetLookUp(String  serverName,
+                       String  serverURLRoot,
+                       String  clientUserId)
+    {
+        this.serverName = serverName;
+        this.serverURLRoot = serverURLRoot;
+        this.clientUserId = clientUserId;
+
+        try
+        {
+            client = new AssetConsumer(serverName, serverURLRoot);
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an exception when creating the Asset Consumer OMAS client.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    String locateAsset()
+    {
+        return null;
+    }
+
+    /**
+     * This method displays a retrieved asset.
+     *
+     * @param assetGUID unique identifier of the asset
+     */
+    void displayAsset(String assetGUID)
+    {
+        try
+        {
+            client = new AssetConsumer(serverName, serverURLRoot);
+
+            AssetUniverse assetUniverse = client.getAssetProperties(clientUserId, assetGUID);
+
+
+
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was a " + error.getClass().getName() + " exception when calling the Asset Consumer OMAS client.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Main program that controls the operation of the sample.  The parameters are passed space separated.
+     * The file name must be passed as parameter 1.  The other parameters are used to override the
+     * sample's default values.
+     *
+     * @param args 1. file name 2. server name, 3. URL root for the server, 4. client userId
+     */
+    public static void main(String[] args)
+    {
+        String  serverName = "cocoMDS2";
+        String  serverURLRoot = "https://localhost:9443";
+        String  clientUserId = "erinoverview";
+
+
+        if (args.length > 1)
+        {
+            serverName = args[1];
+        }
+
+        if (args.length > 2)
+        {
+            serverURLRoot = args[2];
+        }
+
+        if (args.length > 3)
+        {
+            clientUserId = args[3];
+        }
+
+        System.out.println("===============================");
+        System.out.println("Asset Look Up   ");
+        System.out.println("===============================");
+        System.out.println("Running against server: " + serverName + " at " + serverURLRoot);
+        System.out.println("Using userId: " + clientUserId);
+        System.out.println();
+
+        HttpHelper.noStrictSSLIfConfigured();
+
+
+        try
+        {
+            AssetLookUp assetLookUp = new AssetLookUp(serverName, serverURLRoot, clientUserId);
+
+            String assetGUID = assetLookUp.locateAsset();
+            assetLookUp.displayAsset(assetGUID);
+        }
+        catch (Exception  error)
+        {
+            System.out.println("Exception: " + error.getClass().getName() + " with message " + error.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/asset-look-up/src/main/resources/logback.xml
+++ b/asset-look-up/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="OFF">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/asset-set-up/README.md
+++ b/asset-set-up/README.md
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+
+# The Egeria Config Utility (egeria-config-utility)
+
+The Egeria config utility creates configuration documents for OMAG servers.  It has two modes
+of operation:
+
+* *Interactive* - the utility loops waiting for more commands.  It is designed to run
+  IntelliJ (or similar IDE) where it is available for new commands as you work with Egeria.
+  
+* *Command* - the utility takes parameters to describe the server and it is configured in a
+  single request.
+
+This utility works from a set of hard-coded defaults that you can change for your environment.  
+There is also plenty of scope to add new options to configure different types of servers and
+features.
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the Egeria project.

--- a/asset-set-up/pom.xml
+++ b/asset-set-up/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>egeria-dev-projects</artifactId>
+        <groupId>org.odpi.egeria</groupId>
+        <version>3.6-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Asset Set up</name>
+    <description>
+        Creates sample asset catalog entry using different client APIs.
+    </description>
+
+    <artifactId>asset-set-up</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-connector-framework</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>asset-consumer-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>asset-owner-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>asset-manager-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>data-manager-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>digital-architecture-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>governance-program-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>governance-program-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>it-infrastructure-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>subject-area-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>http-helper</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/asset-set-up/src/main/java/org/odpi/openmetadata/devprojects/utilities/assetsetup/AssetSetUp.java
+++ b/asset-set-up/src/main/java/org/odpi/openmetadata/devprojects/utilities/assetsetup/AssetSetUp.java
@@ -1,0 +1,181 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.utilities.assetsetup;
+
+import org.odpi.openmetadata.accessservices.assetconsumer.client.AssetConsumer;
+import org.odpi.openmetadata.accessservices.assetowner.client.CSVFileAssetOwner;
+import org.odpi.openmetadata.accessservices.datamanager.client.DatabaseManagerClient;
+import org.odpi.openmetadata.accessservices.datamanager.client.ExternalReferenceManagerClient;
+import org.odpi.openmetadata.accessservices.digitalarchitecture.client.ConnectionManager;
+import org.odpi.openmetadata.accessservices.digitalarchitecture.client.LocationManager;
+import org.odpi.openmetadata.accessservices.digitalarchitecture.client.ValidValuesManager;
+import org.odpi.openmetadata.accessservices.governanceprogram.client.GovernanceZoneManager;
+import org.odpi.openmetadata.accessservices.governanceprogram.client.SubjectAreaManager;
+import org.odpi.openmetadata.accessservices.governanceprogram.properties.GovernanceZoneProperties;
+import org.odpi.openmetadata.accessservices.assetmanager.client.ExternalAssetManagerClient;
+import org.odpi.openmetadata.accessservices.itinfrastructure.client.CapabilityManagerClient;
+import org.odpi.openmetadata.accessservices.subjectarea.SubjectArea;
+import org.odpi.openmetadata.frameworks.connectors.ffdc.InvalidParameterException;
+import org.odpi.openmetadata.frameworks.connectors.ffdc.PropertyServerException;
+import org.odpi.openmetadata.frameworks.connectors.ffdc.UserNotAuthorizedException;
+import org.odpi.openmetadata.http.HttpHelper;
+
+
+/**
+ * AssetSetUp illustrates the use of the Governance Program OMAS API to create governance zones
+ * for Coco Pharmaceuticals.
+ */
+public class AssetSetUp
+{
+    private String serverName;
+    private String serverURLRoot;
+    private String clientUserId;
+
+    private AssetConsumer                  assetConsumerClient            = null;
+    private CSVFileAssetOwner              csvOnboardingClient            = null;
+    private GovernanceZoneManager          governanceZoneManager          = null;
+    private SubjectAreaManager             subjectAreaManager             = null;
+    private SubjectArea                    subjectAreaClient              = null;
+    private ExternalAssetManagerClient     externalAssetManagerClient     = null;
+    private DatabaseManagerClient          databaseManagerClient          = null;
+    private ExternalReferenceManagerClient externalReferenceManagerClient = null;
+    private ConnectionManager              connectionManager              = null;
+    private LocationManager                locationManager                = null;
+    private ValidValuesManager             validValuesManager             = null;
+    private CapabilityManagerClient        capabilityManagerClient        = null;
+
+    /**
+     * Set up the parameters for the sample.
+     *
+     * @param serverName server to call
+     * @param serverURLRoot location of server
+     * @param clientUserId userId to access the server
+     */
+    public AssetSetUp(String serverName,
+                      String serverURLRoot,
+                      String clientUserId)
+    {
+        this.serverName = serverName;
+        this.serverURLRoot = serverURLRoot;
+        this.clientUserId = clientUserId;
+    }
+
+
+    /**
+     * Set up a new zone
+     *
+     * @param zoneName qualified name
+     * @param displayName display name
+     * @param description longer description
+     * @param criteria what types of assets are found in this zone
+     * @throws InvalidParameterException bad parameters passed to governanceZoneManager
+     * @throws UserNotAuthorizedException userId is not allowed to create zones
+     * @throws PropertyServerException service is not running - or is in trouble
+     */
+    private void createZone(String     zoneName,
+                            String     displayName,
+                            String     description,
+                            String     criteria) throws InvalidParameterException,
+                                                        UserNotAuthorizedException,
+                                                        PropertyServerException
+    {
+        System.out.println("------------------------------------------------------------------------");
+        System.out.println(zoneName);
+        System.out.println("------------------------------------------------------------------------");
+        System.out.println(" ==> qualifiedName: " + zoneName);
+        System.out.println(" ==> displayName:   " + displayName);
+        System.out.println(" ==> description:   " + description);
+        System.out.println(" ==> criteria:      " + criteria);
+        System.out.println(" ");
+
+        GovernanceZoneProperties zoneProperties = new GovernanceZoneProperties();
+
+        zoneProperties.setQualifiedName(zoneName);
+        zoneProperties.setDisplayName(displayName);
+        zoneProperties.setDescription(description);
+        zoneProperties.setCriteria(criteria);
+
+        governanceZoneManager.createGovernanceZone(clientUserId, zoneProperties);
+    }
+
+
+    /**
+     * This runs the sample
+     */
+    public void run()
+    {
+        try
+        {
+            governanceZoneManager = new GovernanceZoneManager(serverName, serverURLRoot);
+
+            GovernanceZoneSampleDefinitions[] zoneSampleDefinitions = GovernanceZoneSampleDefinitions.values();
+
+            for (GovernanceZoneSampleDefinitions zoneDefinition : zoneSampleDefinitions)
+            {
+                createZone(zoneDefinition.getZoneName(),
+                           zoneDefinition.getDisplayName(),
+                           zoneDefinition.getDescription(),
+                           zoneDefinition.getCriteria());
+            }
+
+
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an exception when calling the GovernanceZoneManager governanceZoneManager.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Main program that controls the operation of the sample.  The parameters are passed space separated.
+     * The file name must be passed as parameter 1.  The other parameters are used to override the
+     * sample's default values.
+     *
+     * @param args 1. file name 2. server name, 3. URL root for the server, 4. governanceZoneManager userId
+     */
+    public static void main(String[] args)
+    {
+        String  serverName = "cocoMDS2";
+        String  serverURLRoot = "https://localhost:9443";
+        String  clientUserId = "erinoverview";
+
+
+        if (args.length > 1)
+        {
+            serverName = args[1];
+        }
+
+        if (args.length > 2)
+        {
+            serverURLRoot = args[2];
+        }
+
+        if (args.length > 3)
+        {
+            clientUserId = args[3];
+        }
+
+        System.out.println("===============================");
+        System.out.println("Create Governance Zones Sample   ");
+        System.out.println("===============================");
+        System.out.println("Running against server: " + serverName + " at " + serverURLRoot);
+        System.out.println("Using userId: " + clientUserId);
+        System.out.println();
+
+        HttpHelper.noStrictSSLIfConfigured();
+
+
+        try
+        {
+            AssetSetUp sample = new AssetSetUp(serverName, serverURLRoot, clientUserId);
+
+            sample.run();
+        }
+        catch (Exception  error)
+        {
+            System.out.println("Exception: " + error.getClass().getName() + " with message " + error.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/asset-set-up/src/main/java/org/odpi/openmetadata/devprojects/utilities/assetsetup/GovernanceZoneSampleDefinitions.java
+++ b/asset-set-up/src/main/java/org/odpi/openmetadata/devprojects/utilities/assetsetup/GovernanceZoneSampleDefinitions.java
@@ -1,0 +1,149 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.utilities.assetsetup;
+
+
+/**
+ * The GovernanceZoneSampleDefinitions is used to feed the definition of the governance zones for
+ * Coco Pharmaceuticals.
+ */
+public enum GovernanceZoneSampleDefinitions
+{
+    PERSONAL(   "personal-files",
+                "Personal Files Zone",
+                "Assets that are for an individual's use.  Initially the creator of the asset is the owner. " +
+                      "This person can reassign the asset to additional zones to increase its visibility or " +
+                      "reassign the ownership.",
+                "Assets that should only be visible and editable to the owner."),
+
+    QUARANTINE( "quarantine",
+                "Quarantine Zone",
+                "Assets from third parties that are being evaluated by the onboarding team. " +
+                        "The assets will move into the other zones once the asset has been catalogued and classified.",
+                "Data sets just received and have not yet been properly catalogued."),
+
+    DATA_LAKE( "data-lake",
+                "Data Lake Zone",
+                "Assets for sharing that are read only.",
+                "These are production assets that can be used for business decisions."),
+
+    RESEARCH( "research",
+                "Research Zone",
+                "Research data sets and findings",
+                "Assets that are driving the development of new products and techniques."),
+
+    CLINICAL_TRIALS( "clinical-trials",
+                "Clinical Trials Zone",
+                "Patient data, protocols, outcomes and analysis used within a clinical trial." +
+                             "This data is highly confidential and has restricted access.  It is also subject " +
+                             "to the data management requirements of the regulators.",
+                "Asset supporting the clinical trials."),
+
+    HUMAN_RESOURCES( "human-resources",
+                "Human Resources (Personnel) Zone",
+                "Assets used to manage and support employees of Coco Pharmaceuticals.",
+                "Assets controlled by the HR and management teams."),
+
+    FINANCE( "finance",
+                "Finance Zone",
+                "Assets that support the financial management of Coco Pharmaceuticals.",
+                "Assets controlled by the finance team."),
+
+    INFRASTRUCTURE("infrastructure",
+                "IT Infrastructure Zone",
+                "Assets that describe the IT infrastructure such as hosts, servers, applications, " +
+                            "databases and network infrastructure descriptions.",
+                "Assets controlled by the IT Infrastructure team."),
+
+    DEVELOPMENT("development",
+                "Development and DevOps Zone",
+                "Software development components and assets that support their ongoing development.",
+                "Software development and devops assets."),
+
+    MANUFACTURING( "manufacturing",
+                "Supply, Manufacturing and Distribution Zone",
+                "Suppliers, manufacturing infrastructure, schedules and outputs.",
+                "These are the assets that support the production of Coco Pharmaceutical's products."),
+
+    SALES(      "sales",
+                "Sales Zone",
+                "Customers, sales plans, orders and fulfilment tracking.",
+                "Assets supported by the sales teams."),
+
+    GOVERNANCE( "governance",
+                "Governance Zone",
+                "Governance definitions, monitoring and reporting assets.",
+                "Assets that support the governance team"),
+
+    TRASH_CAN(  "trash-can",
+                "Trash Can Zone",
+                "Asset that are in a holding zone ready to be deleted.",
+                "Assets that are no longer required.")
+;
+
+
+    private String   zoneName;
+    private String   displayName;
+    private String   description;
+    private String   criteria;
+
+
+    /**
+     * GovernanceZoneSampleDefinitions constructor creates an instance of the enum
+     *
+     * @param zoneName   unique Id for the zone
+     * @param displayName   text for the zone
+     * @param description   description of the assets in the zone
+     * @param criteria   criteria for inclusion
+     */
+    GovernanceZoneSampleDefinitions(String zoneName, String displayName, String description, String criteria)
+    {
+        this.zoneName = zoneName;
+        this.displayName = displayName;
+        this.description = description;
+        this.criteria = criteria;
+    }
+
+
+    /**
+     * Returns the unique name for the zone.
+     *
+     * @return qualified name
+     */
+    public String getZoneName()
+    {
+        return zoneName;
+    }
+
+
+    /**
+     * Returns a descriptive name of the zone.
+     *
+     * @return display name
+     */
+    public String getDisplayName()
+    {
+        return displayName;
+    }
+
+    /**
+     * Returns a detailed description of the assets within the zone.
+     *
+     * @return description
+     */
+    public String getDescription()
+    {
+        return description;
+    }
+
+
+    /**
+     * Returns a description of the criteria for including assets in the zone.
+     *
+     * @return criteria
+     */
+    public String getCriteria()
+    {
+        return criteria;
+    }
+}

--- a/asset-set-up/src/main/resources/logback.xml
+++ b/asset-set-up/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="OFF">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/component-id-report/README.md
+++ b/component-id-report/README.md
@@ -1,0 +1,14 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+
+## Component Id Report (component-id-report)
+
+Each component that registers with the audit log provides a component description. This
+sample project creates a list of components and connectors that are shipped by the Egeria
+project.  Feel free to extend it with your own components.
+
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the Egeria project.

--- a/component-id-report/pom.xml
+++ b/component-id-report/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>egeria-dev-projects</artifactId>
+        <groupId>org.odpi.egeria</groupId>
+        <version>3.6-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Component Id Report</name>
+    <description>
+        Lists the component Ids used to register with the audit log for popular Egeria services and connectors.
+    </description>
+
+    <artifactId>component-id-report</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>audit-log-framework</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-connector-framework</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>repository-services-apis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>admin-services-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>integration-daemon-services-registration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>cohort-registry-file-store-connector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-metadata-archive-file-connector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-metadata-archive-directory-connector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>inmemory-repository-connector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>omrs-rest-repository-connector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-metadata-security-samples</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <archive>
+                                <manifest>
+                                    <mainClass>org.odpi.openmetadata.devprojects.reports.componentid.ComponentIdReport</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/component-id-report/src/main/java/org/odpi/openmetadata/devprojects/reports/componentid/ComponentIdReport.java
+++ b/component-id-report/src/main/java/org/odpi/openmetadata/devprojects/reports/componentid/ComponentIdReport.java
@@ -1,0 +1,231 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.reports.componentid;
+
+import org.odpi.openmetadata.adminservices.configuration.registration.AccessServiceDescription;
+import org.odpi.openmetadata.adminservices.configuration.registration.EngineServiceDescription;
+import org.odpi.openmetadata.adminservices.configuration.registration.ViewServiceDescription;
+import org.odpi.openmetadata.frameworks.auditlog.AuditLogReportingComponent;
+import org.odpi.openmetadata.frameworks.auditlog.ComponentDescription;
+import org.odpi.openmetadata.frameworks.connectors.ConnectorProviderBase;
+import org.odpi.openmetadata.governanceservers.integrationdaemonservices.registration.IntegrationServiceDescription;
+import org.odpi.openmetadata.repositoryservices.auditlog.OMRSAuditingComponent;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * ComponentIdReport outputs a list of component identifiers used by popular Egeria services and connectors.
+ */
+public class ComponentIdReport
+{
+    private static String reportFileName = "component-id-report.md";
+    private static String licenseString = "<!-- SPDX-License-Identifier: CC-BY-4.0 -->\n";
+    private static String copyrightString = "<!-- Copyright Contributors to the Egeria project. -->\n\n";
+    private static String reportHeader = "| ComponentId | ComponentName | ComponentDescription | Component Home Page | \n| :--- | :--- | :--- | :--- |\n";
+    private static String snippetString = "\n--8<-- \"snippets/abbr.md\"";
+
+    private static String fileCohortRegistryConnector = "org.odpi.openmetadata.adapters.repositoryservices.cohortregistrystore.file.FileBasedRegistryStoreProvider";
+    private static String directoryMetadataArchiveConnector = "org.odpi.openmetadata.adapters.repositoryservices.archiveconnector.directory.DirectoryBasedOpenMetadataArchiveStoreProvider";
+    private static String fileMetadataArchiveConnector = "org.odpi.openmetadata.adapters.repositoryservices.archiveconnector.file.FileBasedOpenMetadataArchiveStoreProvider";
+    private static String inMemRepositoryConnector = "org.odpi.openmetadata.adapters.repositoryservices.inmemory.repositoryconnector.InMemoryOMRSRepositoryConnectorProvider";
+    private static String readOnlyRepositoryConnector = "org.odpi.openmetadata.adapters.repositoryservices.readonly.repositoryconnector.ReadOnlyOMRSRepositoryConnectorProvider";
+    private static String restRepositoryConnector = "org.odpi.openmetadata.adapters.repositoryservices.rest.repositoryconnector.OMRSRESTRepositoryConnectorProvider";
+    private static String platformSecurityConnectorProviderClassName = "org.odpi.openmetadata.metadatasecurity.samples.CocoPharmaPlatformSecurityProvider";
+    private static String serverSecurityConnectorProviderClassName = "org.odpi.openmetadata.metadatasecurity.samples.CocoPharmaServerSecurityProvider";
+
+
+    /**
+     * Return the component description for a connector.  This is managed by its connector provider.
+     *
+     * @param connectorProviderClassName name of the connector provider.
+     * @return component description or null
+     */
+    private ComponentDescription getConnectorDescription(String connectorProviderClassName)
+    {
+        try
+        {
+            Class<?> connectorProviderClass = Class.forName(connectorProviderClassName);
+
+            Object potentialConnectorProvider = connectorProviderClass.getConstructor().newInstance();
+
+            if (potentialConnectorProvider instanceof ConnectorProviderBase)
+            {
+                ConnectorProviderBase connectorProvider = (ConnectorProviderBase) potentialConnectorProvider;
+
+                return connectorProvider.getConnectorComponentDescription();
+            }
+        }
+        catch (Exception error)
+        {
+            System.out.println("Exception: " + error.getClass().getName() + " with message " + error.getMessage());
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Add the description of the supplied connector to the report.
+     *
+     * @param connectorProviderClassName class name of the connector's connector provider where the component description is managed
+     * @param report report map
+     */
+    private void addConnectorDescription(String                             connectorProviderClassName,
+                                         Map<Integer, ComponentDescription> report)
+    {
+        ComponentDescription connectorComponentDescription = this.getConnectorDescription(connectorProviderClassName);
+
+        if (connectorComponentDescription != null)
+        {
+            ComponentDescription existingComponentDescription = report.put(connectorComponentDescription.getComponentId(), connectorComponentDescription);
+
+            if (existingComponentDescription != null)
+            {
+                System.out.println("Error - componentId conflict between: " + existingComponentDescription.getComponentName() + " and: " + connectorComponentDescription.getComponentName());
+            }
+        }
+    }
+
+    /**
+     * This runs the sample
+     */
+    public void run() throws IOException
+    {
+        Map<Integer, ComponentDescription> report = new TreeMap<>();
+
+        for (AccessServiceDescription serviceDescription : AccessServiceDescription.values())
+        {
+            ComponentDescription componentDescription = new AuditLogReportingComponent(serviceDescription.getAccessServiceCode(),
+                                                                                       serviceDescription.getAccessServiceName(),
+                                                                                       serviceDescription.getAccessServiceDescription(),
+                                                                                       serviceDescription.getAccessServiceWiki());
+
+            ComponentDescription existingComponentDescription = report.put(componentDescription.getComponentId(), componentDescription);
+
+            if (existingComponentDescription != null)
+            {
+                System.out.println("Error - componentId conflict between: " + existingComponentDescription.getComponentName() + " and: " + componentDescription.getComponentName());
+            }
+        }
+
+        for (EngineServiceDescription serviceDescription : EngineServiceDescription.values())
+        {
+            ComponentDescription componentDescription = new AuditLogReportingComponent(serviceDescription.getEngineServiceCode(),
+                                                                                       serviceDescription.getEngineServiceName(),
+                                                                                       serviceDescription.getEngineServiceDescription(),
+                                                                                       serviceDescription.getEngineServiceWiki());
+
+            ComponentDescription existingComponentDescription = report.put(componentDescription.getComponentId(), componentDescription);
+
+            if (existingComponentDescription != null)
+            {
+                System.out.println("Error - componentId conflict between: " + existingComponentDescription.getComponentName() + " and: " + componentDescription.getComponentName());
+            }
+        }
+
+        for (IntegrationServiceDescription serviceDescription : IntegrationServiceDescription.values())
+        {
+            ComponentDescription componentDescription = new AuditLogReportingComponent(serviceDescription.getIntegrationServiceCode(),
+                                                                                       serviceDescription.getIntegrationServiceName(),
+                                                                                       serviceDescription.getIntegrationServiceDescription(),
+                                                                                       serviceDescription.getIntegrationServiceWiki());
+
+            ComponentDescription existingComponentDescription = report.put(componentDescription.getComponentId(), componentDescription);
+
+            if (existingComponentDescription != null)
+            {
+                System.out.println("Error - componentId conflict between: " + existingComponentDescription.getComponentName() + " and: " + componentDescription.getComponentName());
+            }
+        }
+
+        for (ViewServiceDescription serviceDescription : ViewServiceDescription.values())
+        {
+            ComponentDescription componentDescription = new AuditLogReportingComponent(serviceDescription.getViewServiceCode(),
+                                                                                       serviceDescription.getViewServiceName(),
+                                                                                       serviceDescription.getViewServiceDescription(),
+                                                                                       serviceDescription.getViewServiceWiki());
+
+            ComponentDescription existingComponentDescription = report.put(componentDescription.getComponentId(), componentDescription);
+
+            if (existingComponentDescription != null)
+            {
+                System.out.println("Error - componentId conflict between: " + existingComponentDescription.getComponentName() + " and: " + componentDescription.getComponentName());
+            }
+        }
+
+        for (OMRSAuditingComponent serviceDescription : OMRSAuditingComponent.values())
+        {
+            ComponentDescription componentDescription = new AuditLogReportingComponent(serviceDescription.getComponentId(),
+                                                                                       serviceDescription.getComponentName(),
+                                                                                       serviceDescription.getComponentType(),
+                                                                                       serviceDescription.getComponentWikiURL());
+
+            ComponentDescription existingComponentDescription = report.put(componentDescription.getComponentId(), componentDescription);
+
+            if (existingComponentDescription != null)
+            {
+                System.out.println("Error - componentId conflict between: " + existingComponentDescription.getComponentName() + " and: " + componentDescription.getComponentName());
+            }
+        }
+
+        this.addConnectorDescription(fileCohortRegistryConnector, report);
+        this.addConnectorDescription(directoryMetadataArchiveConnector, report);
+        this.addConnectorDescription(fileMetadataArchiveConnector, report);
+        this.addConnectorDescription(inMemRepositoryConnector, report);
+        this.addConnectorDescription(readOnlyRepositoryConnector, report);
+        this.addConnectorDescription(restRepositoryConnector, report);
+        this.addConnectorDescription(platformSecurityConnectorProviderClassName, report);
+        this.addConnectorDescription(serverSecurityConnectorProviderClassName, report);
+
+        File reportFile = new File(reportFileName);
+
+        if (reportFile.exists())
+        {
+            reportFile.delete();
+        }
+
+        FileOutputStream fileOutStream = new FileOutputStream(reportFile);
+
+        fileOutStream.write(licenseString.getBytes());
+        fileOutStream.write(copyrightString.getBytes());
+        fileOutStream.write(reportHeader.getBytes());
+
+        for (Integer componentId : report.keySet())
+        {
+            ComponentDescription componentDescription = report.get(componentId);
+
+            String reportLine = "|" + componentDescription.getComponentId() + "|" + componentDescription.getComponentName() + "|" + componentDescription.getComponentType() + "|" + componentDescription.getComponentWikiURL() + "|\n";
+            fileOutStream.write(reportLine.getBytes());
+            System.out.print(reportLine);
+        }
+
+        fileOutStream.write(snippetString.getBytes());
+    }
+
+
+    /**
+     * Main program that controls the operation of the sample.  The parameters are passed space separated.
+     * The file name must be passed as parameter 1.  The other parameters are used to override the
+     * sample's default values.
+     *
+     * @param args 1. file name 2. server name, 3. URL root for the server, 4. client userId
+     */
+    public static void main(String[] args)
+    {
+        try
+        {
+            ComponentIdReport report = new ComponentIdReport();
+
+            report.run();
+        }
+        catch (Exception  error)
+        {
+            System.out.println("Exception: " + error.getClass().getName() + " with message " + error.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/component-id-report/src/main/resources/logback.xml
+++ b/component-id-report/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="OFF">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/egeria-config-utility/README.md
+++ b/egeria-config-utility/README.md
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+
+# The Egeria Config Utility (egeria-config-utility)
+
+The Egeria config utility creates configuration documents for OMAG servers.  It has two modes
+of operation:
+
+* *Interactive* - the utility loops waiting for more commands.  It is designed to run
+  IntelliJ (or similar IDE) where it is available for new commands as you work with Egeria.
+  
+* *Command* - the utility takes parameters to describe the server and it is configured in a
+  single request.
+
+This utility works from a set of hard-coded defaults that you can change for your environment.  
+There is also plenty of scope to add new options to configure different types of servers and
+features.
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the Egeria project.

--- a/egeria-config-utility/pom.xml
+++ b/egeria-config-utility/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>egeria-dev-projects</artifactId>
+        <groupId>org.odpi.egeria</groupId>
+        <version>3.6-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Egeria Config Utility</name>
+    <description>
+        Simple commands to configure OMAG Servers.
+    </description>
+
+    <artifactId>egeria-config-utility</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-connector-framework</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>repository-services-apis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>admin-services-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>admin-services-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>http-helper</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <archive>
+                                <manifest>
+                                    <mainClass>org.odpi.openmetadata.devprojects.utilities.serverconfig.ServerConfig</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/egeria-config-utility/src/main/java/org/odpi/openmetadata/devprojects/utilities/serverconfig/ServerConfig.java
+++ b/egeria-config-utility/src/main/java/org/odpi/openmetadata/devprojects/utilities/serverconfig/ServerConfig.java
@@ -33,7 +33,7 @@ import java.util.UUID;
  */
 public class ServerConfig
 {
-    private static String serverSecurityConnectorProviderClassName     = null; // "org.odpi.openmetadata.metadatasecurity.samples.CocoPharmaServerSecurityProvider";
+    private static String serverSecurityConnectorProviderClassName     = "org.odpi.openmetadata.metadatasecurity.samples.CocoPharmaServerSecurityProvider";
     private static String kafkaTopicsCaptureConnectorProviderClassName = "org.odpi.openmetadata.devprojects.connectors.integration.kafka.KafkaTopicsCaptureIntegrationProvider";
     private static String eventsDisplayConnectorProviderClassName      = "org.odpi.openmetadata.devprojects.connectors.auditlog.eventdisplay.EventDisplayAuditLogStoreProvider";
     private static String eventBusURLRoot = "localhost:9092"; // set to null to turn off all eventing to Kafka topics

--- a/egeria-config-utility/src/main/java/org/odpi/openmetadata/devprojects/utilities/serverconfig/ServerConfig.java
+++ b/egeria-config-utility/src/main/java/org/odpi/openmetadata/devprojects/utilities/serverconfig/ServerConfig.java
@@ -1,0 +1,689 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.utilities.serverconfig;
+
+import org.odpi.openmetadata.adminservices.client.IntegrationDaemonConfigurationClient;
+import org.odpi.openmetadata.adminservices.client.CohortMemberConfigurationClient;
+import org.odpi.openmetadata.adminservices.client.MetadataAccessStoreConfigurationClient;
+import org.odpi.openmetadata.adminservices.client.OMAGServerConfigurationClient;
+import org.odpi.openmetadata.adminservices.configuration.properties.IntegrationConnectorConfig;
+import org.odpi.openmetadata.adminservices.configuration.properties.IntegrationServiceConfig;
+import org.odpi.openmetadata.adminservices.ffdc.exception.OMAGConfigurationErrorException;
+import org.odpi.openmetadata.adminservices.ffdc.exception.OMAGInvalidParameterException;
+import org.odpi.openmetadata.adminservices.ffdc.exception.OMAGNotAuthorizedException;
+import org.odpi.openmetadata.frameworks.connectors.properties.beans.Connection;
+import org.odpi.openmetadata.frameworks.connectors.properties.beans.ConnectorType;
+import org.odpi.openmetadata.http.HttpHelper;
+import org.odpi.openmetadata.repositoryservices.auditlog.OMRSAuditLogRecordSeverity;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.auditlogstore.OMRSAuditLogStoreProviderBase;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * ServerConfig creates configuration documents that used by servers to define the subsystems and connectors
+ * that should be started when the server starts up.
+ */
+public class ServerConfig
+{
+    private static String serverSecurityConnectorProviderClassName     = null; // "org.odpi.openmetadata.metadatasecurity.samples.CocoPharmaServerSecurityProvider";
+    private static String kafkaTopicsCaptureConnectorProviderClassName = "org.odpi.openmetadata.devprojects.connectors.integration.kafka.KafkaTopicsCaptureIntegrationProvider";
+    private static String eventsDisplayConnectorProviderClassName      = "org.odpi.openmetadata.devprojects.connectors.auditlog.eventdisplay.EventDisplayAuditLogStoreProvider";
+    private static String eventBusURLRoot = "localhost:9092"; // set to null to turn off all eventing to Kafka topics
+    private static String organizationName = "Coco Pharmaceuticals";
+    private static int    maxPageSize = 600;
+
+    private String platformURLRoot;
+    private String clientUserId;
+
+
+    /**
+     * Set up the parameters for the sample.
+     *
+     * @param platformURLRoot location of server
+     * @param clientUserId userId to access the server
+     */
+    private ServerConfig(String platformURLRoot,
+                         String clientUserId)
+    {
+        this.platformURLRoot = platformURLRoot;
+        this.clientUserId    = clientUserId;
+    }
+
+
+    /**
+     * Set up the defaults that are used whenever a topic is configured for a server.
+     * Check that the eventBusURLRoot is correct for your Kafka installation.
+     *
+     * @param client client responsible for the server configuration
+     *
+     * @throws OMAGNotAuthorizedException the supplied userId is not authorized to issue this command.
+     * @throws OMAGInvalidParameterException invalid parameter.
+     * @throws OMAGConfigurationErrorException unusual state in the admin server.
+     */
+    private void setEventBus(OMAGServerConfigurationClient client) throws OMAGNotAuthorizedException,
+                                                                          OMAGInvalidParameterException,
+                                                                          OMAGConfigurationErrorException
+    {
+        if (eventBusURLRoot != null)
+        {
+            Map<String, Object> configurationProperties = new HashMap<>();
+            Map<String, Object> producerProperties      = new HashMap<>();
+            Map<String, Object> consumerProperties      = new HashMap<>();
+
+            producerProperties.put("bootstrap.servers", eventBusURLRoot);
+            consumerProperties.put("bootstrap.servers", eventBusURLRoot);
+            consumerProperties.put("auto.commit.interval.ms", "1");
+
+            configurationProperties.put("producer", producerProperties);
+            configurationProperties.put("consumer", consumerProperties);
+
+            client.setEventBus(null, // use default - kafka
+                               null, // use default - egeria.omag
+                               configurationProperties);
+        }
+    }
+
+
+    /**
+     * Configure a security connector.  The default connector uses the Coco Pharmaceutical users and rules.
+     * Change the serverSecurityConnectorProviderClassName to null to turn off security in new servers.
+     * Alternatively change the class name for a different connector.
+     *
+     * @param client client responsible for the server configuration
+     *
+     * @throws OMAGNotAuthorizedException the supplied userId is not authorized to issue this command.
+     * @throws OMAGInvalidParameterException invalid parameter.
+     * @throws OMAGConfigurationErrorException unusual state in the admin server.
+     */
+    private void setSecuritySecurityConnector(OMAGServerConfigurationClient client) throws OMAGNotAuthorizedException,
+                                                                                           OMAGInvalidParameterException,
+                                                                                           OMAGConfigurationErrorException
+    {
+        if (serverSecurityConnectorProviderClassName != null)
+        {
+            Connection    connection    = new Connection();
+            ConnectorType connectorType = new ConnectorType();
+
+            connectorType.setConnectorProviderClassName(serverSecurityConnectorProviderClassName);
+            connection.setConnectorType(connectorType);
+
+            client.setServerSecurityConnection(connection);
+        }
+    }
+
+
+    /**
+     * Create a new metadata access store OMAG server with an in-memory repository.
+     * If the event bus is not set up, the access services are configured without in and out topics.
+     *
+     * @param serverName name of the new server
+     */
+    private void createMetadataStore(String serverName)
+    {
+        try
+        {
+            System.out.println("Configuring metadata store: " + serverName);
+
+            MetadataAccessStoreConfigurationClient client = new MetadataAccessStoreConfigurationClient(clientUserId, serverName, platformURLRoot);
+
+            client.setServerDescription("Metadata Access Store called " + serverName + " running on platform " + platformURLRoot);
+            client.setServerUserId(serverName + "npa");
+            client.setServerType(null); // Let the admin service set up the server types
+            client.setOrganizationName(organizationName);
+            client.setMaxPageSize(maxPageSize);
+
+            this.setSecuritySecurityConnector(client);
+            client.setDefaultAuditLog();
+
+            client.setServerURLRoot(platformURLRoot);
+            this.setEventBus(client);
+
+            client.setInMemLocalRepository();
+            client.setLocalMetadataCollectionName(serverName + "'s metadata collection");
+
+            List<String> assetLookupZones = new ArrayList<>();
+
+            assetLookupZones.add("data-lake");
+            assetLookupZones.add("personal-files");
+
+            List<String> personalFilesZone = new ArrayList<>();
+
+            assetLookupZones.add("personal-files");
+
+            List<String> maintenanceZones = new ArrayList<>();
+
+            maintenanceZones.add("quarantine");
+            maintenanceZones.add("trash-can");
+            maintenanceZones.add("data-lake");
+
+            List<String> newDataZone = new ArrayList<>();
+
+            newDataZone.add("quarantine");
+
+            Map<String, Object> accessServiceOptions = new HashMap<>();
+
+
+            if (eventBusURLRoot != null)
+            {
+                accessServiceOptions.put("SupportedZones", assetLookupZones);
+                accessServiceOptions.put("DefaultZones", personalFilesZone);
+
+                client.configureAccessService("asset-consumer", accessServiceOptions);
+
+                accessServiceOptions.put("KarmaPointPlateau", 10);
+
+                client.configureAccessService("community-profile", accessServiceOptions);
+
+                accessServiceOptions = new HashMap<>();
+                accessServiceOptions.put("SupportedZones", maintenanceZones);
+                accessServiceOptions.put("DefaultZones", newDataZone);
+                accessServiceOptions.put("PublishZones", assetLookupZones);
+
+                client.configureAccessService("asset-owner", accessServiceOptions);
+                client.configureAccessService("data-manager", accessServiceOptions);
+                client.configureAccessService("asset-manager", accessServiceOptions);
+                client.configureAccessService("governance-program", accessServiceOptions);
+                client.configureAccessService("digital-architecture", accessServiceOptions);
+            }
+            else // configure the access services without in and out topics
+            {
+                accessServiceOptions.put("SupportedZones", assetLookupZones);
+                accessServiceOptions.put("DefaultZones", personalFilesZone);
+
+                client.configureAccessServiceNoTopics("asset-consumer", accessServiceOptions);
+
+                accessServiceOptions.put("KarmaPointPlateau", 10);
+
+                client.configureAccessServiceNoTopics("community-profile", accessServiceOptions);
+
+                accessServiceOptions = new HashMap<>();
+                accessServiceOptions.put("SupportedZones", maintenanceZones);
+                accessServiceOptions.put("DefaultZones", newDataZone);
+                accessServiceOptions.put("PublishZones", assetLookupZones);
+
+                client.configureAccessServiceNoTopics("asset-owner", accessServiceOptions);
+                client.configureAccessServiceNoTopics("data-manager", accessServiceOptions);
+                client.configureAccessServiceNoTopics("asset-manager", accessServiceOptions);
+                client.configureAccessServiceNoTopics("governance-program", accessServiceOptions);
+                client.configureAccessServiceNoTopics("digital-architecture", accessServiceOptions);
+            }
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when calling the platform.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Print out the audit log connections.
+     *
+     * @param client client used to retrieve the audit log destinations
+     */
+    private void printAuditLogDestinations(OMAGServerConfigurationClient client)
+    {
+        try
+        {
+            List<Connection> auditLogConnections = client.getOMAGServerConfig().getRepositoryServicesConfig().getAuditLogConnections();
+
+            System.out.println(auditLogConnections);
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when printing audit log connections.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Set up the supportedSeverities property in the audit log destination connection.
+     *
+     * @param supportedSeverities list of supported severities
+     * @param auditLogDestination connection object
+     */
+    private void setSupportedAuditLogSeverities(List<String> supportedSeverities,
+                                                Connection   auditLogDestination)
+    {
+        if (supportedSeverities != null)
+        {
+            Map<String, Object> configurationProperties = auditLogDestination.getConfigurationProperties();
+
+            if (configurationProperties == null)
+            {
+                configurationProperties = new HashMap<>();
+            }
+
+            configurationProperties.put(OMRSAuditLogStoreProviderBase.supportedSeveritiesProperty, supportedSeverities);
+            auditLogDestination.setConfigurationProperties(configurationProperties);
+        }
+    }
+
+
+    /**
+     * Add the audit log connector that logs the event payload and turn of event logging in the
+     * default console audit log.
+     *
+     * @param serverName server name to upgrade
+     * @param connectorProviderClassName optional connector provider name (or use the default
+     *                                   value defined in eventsDisplayConnectorProviderClassName)
+     */
+    private void logEventContents(String serverName,
+                                  String connectorProviderClassName)
+    {
+        final String egeriaConsoleAuditLogImplementation = "org.odpi.openmetadata.adapters.repositoryservices.auditlogstore.console.ConsoleAuditLogStoreProvider";
+
+        /*
+         * Create a list of severities for the existing console audit log destination that
+         * removes the EVENT severity. (It already ignores the TRACE and PERFMON severities).
+         */
+        List<OMRSAuditLogRecordSeverity> supportedSeverityDefinitions = Arrays.asList(OMRSAuditLogRecordSeverity.values());
+        List<String>                     consoleSupportedSeverities   = new ArrayList<>();
+
+        for (OMRSAuditLogRecordSeverity severityDefinition : supportedSeverityDefinitions)
+        {
+            if ((! OMRSAuditLogRecordSeverity.EVENT.equals(severityDefinition)) &&
+                (! OMRSAuditLogRecordSeverity.TRACE.equals(severityDefinition)) &&
+                (! OMRSAuditLogRecordSeverity.PERFMON.equals(severityDefinition)))
+            {
+                consoleSupportedSeverities.add(severityDefinition.getName());
+            }
+        }
+
+        try
+        {
+            OMAGServerConfigurationClient client = new OMAGServerConfigurationClient(clientUserId, serverName, platformURLRoot);
+
+            /*
+             * This is the list of configured audit log connections.  Locating the console audit log connection
+             * can be tricky because different organizations may set up the connection objects with different
+             * parameters.  In this example, the audit log destinations using the default implementation of the
+             * console audit log destination are updated.
+             */
+            List<Connection> auditLogConnections = client.getOMAGServerConfig().getRepositoryServicesConfig().getAuditLogConnections();
+
+            if (auditLogConnections != null)
+            {
+                for (Connection auditLogConnection : auditLogConnections)
+                {
+                    if (auditLogConnection != null)
+                    {
+                        ConnectorType auditLogConnectorType = auditLogConnection.getConnectorType();
+
+                        if ((auditLogConnectorType != null) &&
+                            (auditLogConnectorType.getConnectorProviderClassName().equals(egeriaConsoleAuditLogImplementation)))
+                        {
+                            /*
+                             * This is a console audit log connector.
+                             */
+                            this.setSupportedAuditLogSeverities(consoleSupportedSeverities, auditLogConnection);
+                            client.updateAuditLogDestination(auditLogConnection.getQualifiedName(), auditLogConnection);
+                        }
+                    }
+                }
+            }
+
+            /*
+             * Create a connection object for the new connector
+             */
+            Connection    eventDisplayConnection = new Connection();
+            ConnectorType connectorType = new ConnectorType();
+
+            if (connectorProviderClassName == null)
+            {
+                connectorType.setConnectorProviderClassName(eventsDisplayConnectorProviderClassName);
+            }
+            else
+            {
+                connectorType.setConnectorProviderClassName(connectorProviderClassName);
+            }
+
+            eventDisplayConnection.setConnectorType(connectorType);
+            eventDisplayConnection.setQualifiedName("Egeria:Sample:AuditLog:DisplayEventPayloadsOnConsole");
+            eventDisplayConnection.setDisplayName("Display Event Payloads On Console Audit Log Destination");
+
+            List<String> eventDisplaySupportedSeverities = new ArrayList<>();
+            eventDisplaySupportedSeverities.add(OMRSAuditLogRecordSeverity.EVENT.getName());
+
+            client.addAuditLogDestination(eventDisplayConnection);
+
+            printAuditLogDestinations(client);
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when updating audit log connections.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Create a new integration daemon OMAG Server.  It needs to know the name of the metadata server that it will connect to to access
+     * the open metadata ecosystem.
+     *
+     * @param serverName name for new integration daemon
+     * @param metadataStoreName name of existing metadata store
+     */
+    private void createIntegrationDaemon(String serverName,
+                                         String metadataStoreName)
+    {
+        try
+        {
+            System.out.println("Configuring integration daemon: " + serverName);
+
+            IntegrationDaemonConfigurationClient client = new IntegrationDaemonConfigurationClient(clientUserId, serverName, platformURLRoot);
+
+            client.setServerDescription("Integration daemon called " + serverName + " running on platform " + platformURLRoot);
+            client.setServerUserId(serverName + "npa");
+            client.setServerType(null); // Let the admin service set up the server types
+            client.setOrganizationName(organizationName);
+            client.setMaxPageSize(maxPageSize);
+
+            this.setSecuritySecurityConnector(client);
+            client.setDefaultAuditLog();
+
+            client.configureIntegrationService(platformURLRoot,
+                                               metadataStoreName,
+                                               "topic-integrator",
+                                               null,
+                                               null);
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when calling the platform.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Add a new Topic Integration Connector to an Integration Daemon server.
+     *
+     * @param serverName integration daemon server name
+     * @param connectorProviderClassName optional connector provider name use to override default
+     *                                   set up in
+     */
+    private void addTopicConnector(String serverName,
+                                   String connectorProviderClassName)
+    {
+        Connection    connection = new Connection();
+        ConnectorType connectorType = new ConnectorType();
+
+        if (connectorProviderClassName == null)
+        {
+            connectorType.setConnectorProviderClassName(kafkaTopicsCaptureConnectorProviderClassName);
+        }
+        else
+        {
+            connectorType.setConnectorProviderClassName(connectorProviderClassName);
+        }
+        connection.setConnectorType(connectorType);
+
+        IntegrationConnectorConfig integrationConnectorConfig = new IntegrationConnectorConfig();
+
+        integrationConnectorConfig.setConnectorId(UUID.randomUUID().toString());
+        integrationConnectorConfig.setConnectorName("Topic Connector for " + connectorProviderClassName);
+        integrationConnectorConfig.setConnectorUserId(serverName + "npa");
+        integrationConnectorConfig.setConnection(connection);
+
+        try
+        {
+            IntegrationDaemonConfigurationClient client = new IntegrationDaemonConfigurationClient(clientUserId, serverName, platformURLRoot);
+
+            IntegrationServiceConfig topicIntegratorConfig = client.getIntegrationServiceConfiguration("topic-integrator");
+
+            List<IntegrationConnectorConfig> connectorList = topicIntegratorConfig.getIntegrationConnectorConfigs();
+
+            if (connectorList == null)
+            {
+                connectorList = new ArrayList<>();
+            }
+
+            connectorList.add(integrationConnectorConfig);
+
+            topicIntegratorConfig.setIntegrationConnectorConfigs(connectorList);
+
+            client.configureIntegrationService(topicIntegratorConfig);
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when calling the platform.  Error message is: " + error.getMessage());
+        }
+
+    }
+
+
+    /**
+     * Add a server to the named cohort.  This will fail if the event bus is not set up.
+     *
+     * @param serverName name of server to update
+     * @param cohortName name of cohort to join
+     */
+    private void addCohortMember(String serverName,
+                                 String cohortName)
+    {
+        try
+        {
+            CohortMemberConfigurationClient client = new CohortMemberConfigurationClient(clientUserId, serverName, platformURLRoot);
+
+            client.addCohortRegistration(cohortName, null);
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when calling the platform.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Delete a server.
+     *
+     * @param serverName name of server
+     */
+    private void deleteServer(String serverName)
+    {
+        try
+        {
+            OMAGServerConfigurationClient client = new OMAGServerConfigurationClient(clientUserId, serverName, platformURLRoot);
+
+            client.clearOMAGServerConfig();
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when calling the platform.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Run the requested command.
+     *
+     * @param mode command
+     * @param options list of options - first is server name
+     */
+    private void runCommand(String   mode,
+                            String[] options)
+    {
+        final String defaultAuditLogConnectorProvider = "package org.odpi.openmetadata.devprojects.connectors.auditlog.eventdisplay.EventDisplayAuditLogStoreProvider";
+        final String defaultTopicIntegrationConnectorProvider = "";
+        final String defaultCohort = "dojoCohort";
+
+        if ("create-metadata-store".equals(mode))
+        {
+            if (options.length > 0)
+            {
+                this.createMetadataStore(options[0]);
+            }
+            else
+            {
+                System.out.println("  Error: include a server name");
+            }
+        }
+        else if ("create-integration-daemon".equals(mode))
+        {
+            if (options.length > 1)
+            {
+                this.createIntegrationDaemon(options[0], options[1]);
+            }
+            else
+            {
+                System.out.println("  Error: include a server name for the integration daemon and the name of the metadata store that it is to connect to.");
+            }
+
+        }
+        else if ("log-event-contents".equals(mode))
+        {
+            if (options.length == 1)
+            {
+                this.logEventContents(options[0], defaultAuditLogConnectorProvider);
+            }
+            else if (options.length > 1)
+            {
+                this.logEventContents(options[0], options[1]);
+            }
+            else
+            {
+                System.out.println("  Error: include a server name");
+            }
+        }
+        else if ("add-topic-connector".equals(mode))
+        {
+            if (options.length == 1)
+            {
+                this.addTopicConnector(options[0], defaultTopicIntegrationConnectorProvider);
+            }
+            else if (options.length > 1)
+            {
+                this.addTopicConnector(options[0], options[1]);
+            }
+            else
+            {
+                System.out.println("  Error: include a server name");
+            }
+        }
+        else if ("add-cohort-member".equals(mode))
+        {
+            if (options.length == 1)
+            {
+                this.addCohortMember(options[0], defaultCohort);
+            }
+            else if (options.length > 1)
+            {
+                this.addCohortMember(options[0], options[1]);
+            }
+            else
+            {
+                System.out.println("  Error: include a server name");
+            }
+        }
+        else if ("delete-server".equals(mode))
+        {
+            if (options.length > 0)
+            {
+                this.deleteServer(options[0]);
+            }
+            else
+            {
+                System.out.println("  Error: include a server name");
+            }
+        }
+        else
+        {
+            System.out.println("  Error: use a valid command");
+        }
+    }
+
+
+    /**
+     * Main program that controls the operation of the platform report.  The parameters are passed space separated.
+     * The  parameters are used to override the report's default values. If mode is set to "interactive"
+     * the caller is prompted for a command and one to many server names.
+     *
+     * @param args 1. service platform URL root, 2. client userId, 3. mode 4. server name 5. server name ...
+     */
+    public static void main(String[] args)
+    {
+        final String interactiveMode = "interactive";
+        final String endInteractiveMode = "exit";
+
+        String       platformURLRoot = "https://localhost:9443";
+        String       clientUserId = "garygeeke";
+        String       mode = interactiveMode;
+
+        if (args.length > 0)
+        {
+            platformURLRoot = args[0];
+        }
+
+        if (args.length > 1)
+        {
+            clientUserId = args[1];
+        }
+
+        if (args.length > 2)
+        {
+            mode = args[2];
+        }
+
+        System.out.println("===============================");
+        System.out.println("OMAG Server Operations Utility:    " + new Date().toString());
+        System.out.println("===============================");
+        System.out.println("Running against platform: " + platformURLRoot);
+        System.out.println("Using userId: " + clientUserId);
+        System.out.println();
+
+        ServerConfig utility = new ServerConfig(platformURLRoot, clientUserId);
+
+        HttpHelper.noStrictSSLIfConfigured();
+
+        try
+        {
+            if (interactiveMode.equals(mode))
+            {
+                while (! endInteractiveMode.equals(mode))
+                {
+                    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                    System.out.println("Enter a command along with the server name and any optional parameters. Press enter to execute request.");
+                    System.out.println("  - create-metadata-store     <serverName>  ");
+                    System.out.println("  - create-integration-daemon <serverName> <metadataStoreServerName> ");
+                    System.out.println("  - add-topic-connector       <serverName> <optionalConnectorProviderClassName> ");
+                    System.out.println("  - log-event-contents        <serverName> <optionalConnectorProviderClassName> ");
+                    System.out.println("  - add-cohort-member         <serverName> <optionalCohortName> ");
+                    System.out.println("  - delete-server             <serverName>  ");
+                    System.out.println("  - exit  \n");
+
+                    String   command = br.readLine();
+                    String[] commandWords = command.split(" ");
+
+                    if (commandWords.length > 0)
+                    {
+                        mode = commandWords[0];
+
+                        if (commandWords.length > 1)
+                        {
+                            utility.runCommand(mode,  Arrays.copyOfRange(commandWords, 1, commandWords.length));
+                        }
+                    }
+
+                    System.out.println();
+                }
+            }
+            else
+            {
+                utility.runCommand(mode, Arrays.copyOfRange(args, 3, args.length));
+            }
+        }
+        catch (Exception  error)
+        {
+            System.out.println("Exception: " + error.getClass().getName() + " with message " + error.getMessage());
+            System.exit(-1);
+        }
+
+        System.exit(0);
+    }
+}

--- a/egeria-config-utility/src/main/resources/logback.xml
+++ b/egeria-config-utility/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="OFF">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/egeria-ops-utility/README.md
+++ b/egeria-ops-utility/README.md
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+
+# The Egeria Operations Utility (egeria-ops-utility)
+
+The Egeria operations utility creates starts and stops OMAG servers on request.  It has two modes
+of operation:
+
+* *Interactive* - the utility loops waiting for more commands.  It is designed to run
+  IntelliJ (or similar IDE) where it is available for new commands as you work with Egeria.
+  
+* *Command* - the utility takes parameters to describe the server and it is configured in a
+  single request.
+
+This utility works from a set of hard-coded defaults that you can change for your environment.  
+There is also plenty of scope to add new options to configure different types of servers and
+features.
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the Egeria project.

--- a/egeria-ops-utility/pom.xml
+++ b/egeria-ops-utility/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>egeria-dev-projects</artifactId>
+        <groupId>org.odpi.egeria</groupId>
+        <version>3.6-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Egeria Ops Utility</name>
+    <description>
+        Simple commands to start and stop OMAG Servers.
+    </description>
+
+    <artifactId>egeria-ops-utility</artifactId>
+
+    <dependencies>
+
+         <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>admin-services-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>http-helper</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <archive>
+                                <manifest>
+                                    <mainClass>org.odpi.openmetadata.devprojects.utilities.serverops.ServerOps</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/egeria-ops-utility/src/main/java/org/odpi/openmetadata/devprojects/utilities/serverops/ServerOps.java
+++ b/egeria-ops-utility/src/main/java/org/odpi/openmetadata/devprojects/utilities/serverops/ServerOps.java
@@ -1,0 +1,232 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.utilities.serverops;
+
+import org.odpi.openmetadata.adminservices.client.OMAGServerOperationsClient;
+import org.odpi.openmetadata.http.HttpHelper;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * ServerOps provides a utility for starting and stopping servers on an OMAG Server Platform.
+ */
+public class ServerOps
+{
+    private String platformURLRoot;
+    private String clientUserId;
+
+
+    /**
+     * Set up the parameters for the sample.
+     *
+     * @param platformURLRoot location of server
+     * @param clientUserId userId to access the server
+     */
+    private ServerOps(String platformURLRoot,
+                      String clientUserId)
+    {
+        this.platformURLRoot = platformURLRoot;
+        this.clientUserId    = clientUserId;
+    }
+
+
+    /**
+     * Start the named server on the platform.  This will fail if the platform is not running,
+     * or if the user is not authorized to issue operations requests to the platform or if the
+     * server is not configured.
+     *
+     * @param serverName string name
+     */
+    private void startServer(String serverName)
+    {
+        try
+        {
+            OMAGServerOperationsClient client = new OMAGServerOperationsClient(clientUserId, serverName, platformURLRoot);
+
+            System.out.println("Starting " + serverName + " ...");
+            System.out.println(client.activateWithStoredConfig());
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when calling the platform.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Start the list of named servers.
+     *
+     * @param serverNames list of names
+     */
+    private void startServers(List<String> serverNames)
+    {
+        if (serverNames != null)
+        {
+            for (String serverName : serverNames)
+            {
+                if (serverName != null)
+                {
+                    this.startServer(serverName);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Stop the requested server.    This will fail if the server or the platform is not running,
+     * or if the user is not authorized to issue operations requests to the platform.
+     *
+     * @param serverName string name
+     */
+    private void stopServer(String serverName)
+    {
+        try
+        {
+            OMAGServerOperationsClient client = new OMAGServerOperationsClient(clientUserId, serverName, platformURLRoot);
+
+            System.out.println("Stopping " + serverName + " ...");
+
+            client.deactivateTemporarily();
+
+            System.out.println(serverName + " stopped.");
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when calling the platform.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * Stop the list of named servers.
+     *
+     * @param serverNames list of names
+     */
+    private void stopServers(List<String> serverNames)
+    {
+        if (serverNames != null)
+        {
+            for (String serverName : serverNames)
+            {
+                if (serverName != null)
+                {
+                    this.stopServer(serverName);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Run the requested command.
+     *
+     * @param mode command
+     * @param serverArray list of server names
+     */
+    private void runCommand(String   mode,
+                            String[] serverArray)
+    {
+        List<String> serverList = null;
+
+        if (serverArray != null)
+        {
+            serverList = Arrays.asList(serverArray);
+        }
+
+        if ("start".equals(mode))
+        {
+            this.startServers(serverList);
+        }
+        else if ("stop".equals(mode))
+        {
+            this.stopServers(serverList);
+        }
+    }
+
+
+    /**
+     * Main program that controls the operation of the platform report.  The parameters are passed space separated.
+     * The  parameters are used to override the report's default values. If mode is set to "interactive"
+     * the caller is prompted for a command and one to many server names.
+     *
+     * @param args 1. service platform URL root, 2. client userId, 3. mode 4. server name 5. server name ...
+     */
+    public static void main(String[] args)
+    {
+        final String interactiveMode = "interactive";
+        final String endInteractiveMode = "exit";
+
+        String       platformURLRoot = "https://localhost:9443";
+        String       clientUserId = "garygeeke";
+        String       mode = interactiveMode;
+
+        if (args.length > 0)
+        {
+            platformURLRoot = args[0];
+        }
+
+        if (args.length > 1)
+        {
+            clientUserId = args[1];
+        }
+
+        if (args.length > 2)
+        {
+            mode = args[2];
+        }
+
+        System.out.println("===============================");
+        System.out.println("OMAG Server Operations Utility:    " + new Date().toString());
+        System.out.println("===============================");
+        System.out.println("Running against platform: " + platformURLRoot);
+        System.out.println("Using userId: " + clientUserId);
+        System.out.println();
+
+        ServerOps utility = new ServerOps(platformURLRoot, clientUserId);
+
+        HttpHelper.noStrictSSLIfConfigured();
+
+        try
+        {
+            if (interactiveMode.equals(mode))
+            {
+                while (! endInteractiveMode.equals(mode))
+                {
+                    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                    System.out.println("Enter a command {start, stop, exit} along with one or more space separate server names. Press enter to execute request.");
+
+                    String   command = br.readLine();
+                    String[] commandWords = command.split(" ");
+
+                    if (commandWords.length > 0)
+                    {
+                        mode = commandWords[0];
+
+                        if (commandWords.length > 1)
+                        {
+                            utility.runCommand(mode,  Arrays.copyOfRange(commandWords, 1, commandWords.length));
+                        }
+                    }
+
+                    System.out.println();
+                }
+            }
+            else
+            {
+               utility.runCommand(mode, Arrays.copyOfRange(args, 3, args.length));
+            }
+        }
+        catch (Exception  error)
+        {
+            System.out.println("Exception: " + error.getClass().getName() + " with message " + error.getMessage());
+            System.exit(-1);
+        }
+
+        System.exit(0);
+    }
+}

--- a/egeria-ops-utility/src/main/resources/logback.xml
+++ b/egeria-ops-utility/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="OFF">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/egeria-platform-report/README.md
+++ b/egeria-platform-report/README.md
@@ -1,0 +1,31 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+# Egeria Platform Report (egeria-platform-report)
+
+The Egeria platform report is passed a platform URL root (and optional server name) that
+it uses to query the operational status of the platform.  For example:
+
+* Which *version* of Egeria is running
+* Which *Platform Metadata Security Connector* is configured.
+* Which *Configuration Document Store Connector* is configured.
+* Which *Registered Services* are installed.
+* Which *OMAG Servers* are visible to the platform.
+   * For each configured server
+      * What type of server is it and its description
+      * Which services are configured
+      * Which connectors are configured and whether they are installed and usable on the platform
+      * Which cohorts are configured for the server to join (if applicable)
+   * For each known server (ie has run at least once since the platform started):
+      * The time when it has been running on the platform
+   * If the server is still running the following details are added
+      * The running status of its services
+      * The report from the audit log describing the statistics from each component
+      * the registration status of the server with its cohorts (if applicable)
+      * the status of its engines/connectors (if applicable)
+
+
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the Egeria project.

--- a/egeria-platform-report/pom.xml
+++ b/egeria-platform-report/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>egeria-dev-projects</artifactId>
+        <groupId>org.odpi.egeria</groupId>
+        <version>3.6-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Egeria Platform Report</name>
+    <description>
+        Explores and displays thee operational state of an OMAG Server Platform.
+    </description>
+
+    <artifactId>egeria-platform-report</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>egeria-report-utilities</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-connector-framework</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>repository-services-apis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>repository-services-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>admin-services-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>admin-services-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>platform-services-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>platform-services-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>ffdc-services</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>http-helper</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <archive>
+                                <manifest>
+                                    <mainClass>org.odpi.openmetadata.devprojects.reports.platform.EgeriaPlatformReport</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/egeria-platform-report/src/main/java/org/odpi/openmetadata/devprojects/reports/platform/EgeriaPlatformReport.java
+++ b/egeria-platform-report/src/main/java/org/odpi/openmetadata/devprojects/reports/platform/EgeriaPlatformReport.java
@@ -1,0 +1,1258 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.reports.platform;
+
+
+import org.odpi.openmetadata.adminservices.client.ConfigurationManagementClient;
+import org.odpi.openmetadata.adminservices.client.OMAGServerConfigurationClient;
+import org.odpi.openmetadata.adminservices.client.OMAGServerOperationsClient;
+import org.odpi.openmetadata.adminservices.client.OMAGServerPlatformConfigurationClient;
+import org.odpi.openmetadata.adminservices.configuration.properties.AccessServiceConfig;
+import org.odpi.openmetadata.adminservices.configuration.properties.CohortConfig;
+import org.odpi.openmetadata.adminservices.configuration.properties.EngineConfig;
+import org.odpi.openmetadata.adminservices.configuration.properties.EngineServiceConfig;
+import org.odpi.openmetadata.adminservices.configuration.properties.IntegrationConnectorConfig;
+import org.odpi.openmetadata.adminservices.configuration.properties.IntegrationServiceConfig;
+import org.odpi.openmetadata.adminservices.configuration.properties.OMAGServerConfig;
+import org.odpi.openmetadata.adminservices.configuration.properties.ViewServiceConfig;
+import org.odpi.openmetadata.adminservices.configuration.registration.AccessServiceDescription;
+import org.odpi.openmetadata.adminservices.configuration.registration.GovernanceServicesDescription;
+import org.odpi.openmetadata.adminservices.ffdc.exception.OMAGConfigurationErrorException;
+import org.odpi.openmetadata.adminservices.properties.OMAGServerServiceStatus;
+import org.odpi.openmetadata.adminservices.properties.ServerActiveStatus;
+import org.odpi.openmetadata.devprojects.reports.EgeriaReport;
+import org.odpi.openmetadata.frameworks.connectors.ffdc.InvalidParameterException;
+import org.odpi.openmetadata.frameworks.connectors.properties.beans.Connection;
+import org.odpi.openmetadata.http.HttpHelper;
+import org.odpi.openmetadata.platformservices.client.PlatformServicesClient;
+import org.odpi.openmetadata.platformservices.properties.OMAGServerInstanceHistory;
+import org.odpi.openmetadata.repositoryservices.clients.MetadataHighwayServicesClient;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.cohortregistrystore.properties.MemberRegistration;
+import org.odpi.openmetadata.repositoryservices.properties.CohortConnectionStatus;
+import org.odpi.openmetadata.repositoryservices.properties.CohortDescription;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * EgeriaPlatformReport illustrates the use of the Platform Services, Admin Services and Repository Services to pull
+ * together a report of an OMAG Server Platform's services and active servers.
+ */
+public class EgeriaPlatformReport
+{
+    private String           serverOfInterest;
+    private String           platformURLRoot;
+    private String           clientUserId;
+    private EgeriaReport     report;
+
+    /**
+     * Set up the parameters for the sample.
+     *
+     * @param serverOfInterest server to restrict the results
+     * @param platformURLRoot location of server
+     * @param clientUserId userId to access the server
+     * @throws IOException problem writing file
+     */
+    private EgeriaPlatformReport(String serverOfInterest,
+                                 String platformURLRoot,
+                                 String clientUserId) throws IOException
+    {
+        final String reportFileName  = "egeria-platform-report.md";
+
+        this.serverOfInterest = serverOfInterest;
+        this.platformURLRoot = platformURLRoot;
+        this.clientUserId = clientUserId;
+
+        report = new EgeriaReport(reportFileName);
+    }
+
+
+    /**
+     * This runs the sample.
+     */
+    private void run()
+    {
+        int indentLevel = 0;
+
+        try
+        {
+            /*
+             * This client is from the platform services module and queries the runtime state of the platform and the servers that are running on it.
+             */
+            PlatformServicesClient platformServicesClient = new PlatformServicesClient(serverOfInterest, platformURLRoot);
+
+            /*
+             * This outputs the report title
+             */
+            report.printReportTitle(indentLevel, platformURLRoot);
+
+            int detailIndentLevel = indentLevel + 1;
+
+            report.printReportSubheading(detailIndentLevel, "Platform deployment");
+
+            /*
+             * This is the first call to the platform and determines the version of the software.
+             * If the platform is not running, or the remote service is not an OMAG Server Platform,
+             * the report utility fails at this point.
+             */
+            String platformOrigin = platformServicesClient.getPlatformOrigin(clientUserId);
+
+            report.printReportLine(detailIndentLevel + 1, "Egeria version", platformOrigin.replace("\n", ""));
+
+            /*
+             * These clients are from the admin services module. The platform configuration client manages the configuration of the platform.
+             * The configuration management client manages and moves configuration documents for OMAG Servers.  It will be able to
+             * work with all configuration documents that are visible to the platform - not just those servers intended to
+             * run on this platform.
+             */
+            OMAGServerPlatformConfigurationClient platformConfigurationClient   = new OMAGServerPlatformConfigurationClient(clientUserId, platformURLRoot);
+            ConfigurationManagementClient         configurationManagementClient = new ConfigurationManagementClient(clientUserId, platformURLRoot);
+
+            /*
+             * Extract information about the connector that manages the configuration document store.
+             * This is where the configuration for the OMAG Servers is maintained.
+             */
+            report.printConnection(detailIndentLevel + 1,
+                                   "Configuration document store connector",
+                                   platformConfigurationClient.getConfigurationStoreConnection());
+
+            /*
+             * Extract information about the connector that manages the authorization of requests to the platform.
+             */
+            report.printConnection(detailIndentLevel + 1,
+                                   "Platform security connector",
+                                   platformConfigurationClient.getPlatformSecurityConnection());
+
+            /*
+             * List the registered services
+             */
+            report.printReportSubheading(detailIndentLevel, "Registered services");
+
+            report.printRegisteredServices(detailIndentLevel + 1, platformServicesClient.getAccessServices(clientUserId));
+            report.printRegisteredServices(detailIndentLevel + 1, platformServicesClient.getEngineServices(clientUserId));
+            report.printRegisteredServices(detailIndentLevel + 1, platformServicesClient.getIntegrationServices(clientUserId));
+            report.printRegisteredServices(detailIndentLevel + 1, platformServicesClient.getViewServices(clientUserId));
+
+            /*
+             * Collect server details.
+             */
+            Map<String, OMAGServerDetails> serverDetailsMap = new HashMap<>();
+
+            if (serverOfInterest == null)
+            {
+                report.printReportSubheading(detailIndentLevel, "Platform servers");
+
+                /*
+                 * Output requested for all servers
+                 */
+                Set<OMAGServerConfig> configuredServers = configurationManagementClient.getAllServerConfigurations();
+
+                if (configuredServers != null)
+                {
+                    for (OMAGServerConfig serverConfig : configuredServers)
+                    {
+                        OMAGServerDetails currentDetails = serverDetailsMap.get(serverConfig.getLocalServerName());
+
+                        if (currentDetails == null)
+                        {
+                            currentDetails = new OMAGServerDetails(serverConfig.getLocalServerName());
+                        }
+
+                        currentDetails.setConfiguration(serverConfig);
+
+                        serverDetailsMap.put(serverConfig.getLocalServerName(), currentDetails);
+                    }
+                }
+
+                List<String> serverList = platformServicesClient.getKnownServers(clientUserId);
+
+                if (serverList != null)
+                {
+                    for (String serverName : serverList)
+                    {
+                        if (serverName != null)
+                        {
+                            org.odpi.openmetadata.platformservices.properties.ServerStatus platformServerStatus = platformServicesClient.getServerStatus(clientUserId, serverName);
+
+                            if (platformServerStatus != null)
+                            {
+                                OMAGServerDetails currentDetails = serverDetailsMap.get(serverName);
+
+                                if (currentDetails == null)
+                                {
+                                    currentDetails = new OMAGServerDetails(serverName);
+                                }
+
+                                currentDetails.setServerStartTime(platformServerStatus.getServerStartTime());
+                                currentDetails.setServerEndTime(platformServerStatus.getServerEndTime());
+                                currentDetails.setServerHistory(platformServerStatus.getServerHistory());
+                            }
+                        }
+                    }
+                }
+
+                serverList = platformServicesClient.getActiveServers(clientUserId);
+
+                if (serverList != null)
+                {
+                    for (String serverName : serverList)
+                    {
+                        if (serverName != null)
+                        {
+                            /*
+                             * This client provides specific details of a running server - it is provided by the Admin Services mon
+                             */
+                            OMAGServerOperationsClient serverOperationsClient = new OMAGServerOperationsClient(clientUserId,
+                                                                                                               serverName,
+                                                                                                               platformURLRoot);
+
+                            org.odpi.openmetadata.adminservices.properties.ServerStatus adminServerStatus = serverOperationsClient.getServerStatus();
+
+                            if (adminServerStatus != null)
+                            {
+                                OMAGServerDetails currentDetails = serverDetailsMap.get(serverName);
+
+                                if (currentDetails == null)
+                                {
+                                    currentDetails = new OMAGServerDetails(serverName);
+                                }
+
+                                currentDetails.setServerActiveStatus(adminServerStatus.getServerActiveStatus());
+                                currentDetails.setServerType(adminServerStatus.getServerType());
+                                currentDetails.setServices(adminServerStatus.getServices());
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                report.printReportSubheading(detailIndentLevel, "Server of interest");
+
+                OMAGServerDetails serverDetails = new OMAGServerDetails(serverOfInterest);
+
+                OMAGServerConfigurationClient configurationClient = new OMAGServerConfigurationClient(clientUserId, serverOfInterest, platformURLRoot);
+
+                OMAGServerConfig serverConfig = configurationClient.getOMAGServerConfig();
+
+                if (serverConfig != null)
+                {
+                    serverDetails.setConfiguration(serverConfig);
+                }
+
+                try
+                {
+                    org.odpi.openmetadata.platformservices.properties.ServerStatus platformServerStatus = platformServicesClient.getServerStatus(clientUserId, serverOfInterest);
+
+                    if (platformServerStatus != null)
+                    {
+                        serverDetails.setServerStartTime(platformServerStatus.getServerStartTime());
+                        serverDetails.setServerEndTime(platformServerStatus.getServerEndTime());
+                        serverDetails.setServerHistory(platformServerStatus.getServerHistory());
+                    }
+                }
+                catch (InvalidParameterException serverNotRunningException)
+                {
+                    // nothing to do - simply that the server is not running
+                }
+
+                try
+                {
+                    OMAGServerOperationsClient serverOperationsClient = new OMAGServerOperationsClient(clientUserId,
+                                                                                                       serverOfInterest,
+                                                                                                       platformURLRoot);
+
+                    org.odpi.openmetadata.adminservices.properties.ServerStatus adminServerStatus = serverOperationsClient.getServerStatus();
+
+                    if (adminServerStatus != null)
+                    {
+                        serverDetails.setServerActiveStatus(adminServerStatus.getServerActiveStatus());
+                        serverDetails.setServerType(adminServerStatus.getServerType());
+                        serverDetails.setServices(adminServerStatus.getServices());
+                    }
+                }
+                catch (OMAGConfigurationErrorException serverNotRunningException)
+                {
+                    // nothing to do - simply that the server is not running
+                }
+
+                serverDetailsMap.put(serverOfInterest, serverDetails);
+            }
+
+
+            /*
+             * Add runtime information about the cohorts.
+             */
+            for (OMAGServerDetails serverDetails : serverDetailsMap.values())
+            {
+                if (serverDetails != null)
+                {
+                    MetadataHighwayServicesClient metadataHighwayServicesClient = new MetadataHighwayServicesClient(serverDetails.getServerName(), platformURLRoot);
+
+                    try
+                    {
+                        List<CohortDescription> cohorts = metadataHighwayServicesClient.getCohortDescriptions(clientUserId);
+
+                        if (cohorts != null)
+                        {
+                            for (CohortDescription cohortDescription : cohorts)
+                            {
+                                if (cohortDescription != null)
+                                {
+                                    OMAGServerDetails.OMAGCohortDetails cohortDetails = serverDetails.getCohortDetails(cohortDescription.getCohortName());
+
+                                    cohortDetails.setConnectionStatus(cohortDescription.getConnectionStatus());
+
+                                    cohortDetails.setLocalRegistration(metadataHighwayServicesClient.getLocalRegistration(serverDetails.getServerName(),
+                                                                                                                          clientUserId,
+                                                                                                                          cohortDescription.getCohortName()));
+
+                                    cohortDetails.setRemoteRegistrations(metadataHighwayServicesClient.getRemoteRegistrations(serverDetails.getServerName(),
+                                                                                                                              clientUserId,
+                                                                                                                              cohortDescription.getCohortName()));
+                                }
+                            }
+                        }
+                    }
+                    catch (org.odpi.openmetadata.repositoryservices.ffdc.exception.RepositoryErrorException serverNotRunningException)
+                    {
+                        // nothing to do - simply that the server is not running
+                    }
+                }
+            }
+
+            /*
+             * Now all of the details about the servers is assembled, it can be printed out.
+             */
+            for (OMAGServerDetails serverDetails : serverDetailsMap.values())
+            {
+                if (serverDetails != null)
+                {
+                    serverDetails.printServer(detailIndentLevel + 1);
+                }
+            }
+
+            report.closeReport();
+        }
+        catch (Exception error)
+        {
+            System.out.println("There was an " + error.getClass().getName() + " exception when calling the platform.  Error message is: " + error.getMessage());
+        }
+    }
+
+
+    /**
+     * OMAGServerDetails provides a cache to assemble details about a server.  It is initialized through a
+     * series of set method calls that pass information retrieved from the OMAG Server Platform.  It extracts the
+     * interesting values that are to form part of the server report.  Once all that is known about the server has
+     * been assembled
+     */
+    private class OMAGServerDetails
+    {
+        private String                          serverName;
+        private String                          serverType           = null;
+        private OMAGServerConfig                configuration        = null;
+        private ServerActiveStatus              serverActiveStatus   = ServerActiveStatus.UNKNOWN;
+        private Date                            serverStartTime      = null;
+        private Date                            serverEndTime        = null;
+        private List<OMAGServerInstanceHistory> serverHistory        = null;
+        private Map<String, OMAGServiceDetails> serviceDetailsMap    = new HashMap<>();
+        private Map<String, OMAGCohortDetails>  cohortDetailsMap     = new HashMap<>();
+
+
+        /**
+         * Constructor assumes the server name is known.
+         *
+         * @param serverName name of the subject of this object
+         */
+        OMAGServerDetails(String serverName)
+        {
+            this.serverName = serverName;
+        }
+
+
+        /**
+         * Retrieve the name of the server.
+         *
+         * @return string name
+         */
+        String getServerName()
+        {
+            return serverName;
+        }
+
+
+        /**
+         * The configuration identifies the server and the services that it runs.
+         *
+         * @param configuration configuration document for the server
+         */
+        void setConfiguration(OMAGServerConfig configuration)
+        {
+            this.configuration = configuration;
+
+            if (configuration != null)
+            {
+                serverType = configuration.getLocalServerType();
+
+                if (configuration.getRepositoryServicesConfig() != null)
+                {
+                    if (configuration.getRepositoryServicesConfig().getCohortConfigList() != null)
+                    {
+                        for (CohortConfig cohortConfig : configuration.getRepositoryServicesConfig().getCohortConfigList())
+                        {
+                            OMAGCohortDetails currentDetails = this.getCohortDetails(cohortConfig.getCohortName());
+
+                            if (cohortConfig.getCohortRegistryConnection() != null)
+                            {
+                                currentDetails.setConnection("Cohort Registry Store", cohortConfig.getCohortRegistryConnection());
+                            }
+
+                            if (cohortConfig.getCohortOMRSRegistrationTopicConnection() != null)
+                            {
+                                currentDetails.setConnection("Cohort Registration Topic", cohortConfig.getCohortOMRSRegistrationTopicConnection());
+                            }
+
+                            if (cohortConfig.getCohortOMRSTypesTopicConnection() != null)
+                            {
+                                currentDetails.setConnection("Cohort Types Topic", cohortConfig.getCohortOMRSTypesTopicConnection());
+                            }
+
+                            if (cohortConfig.getCohortOMRSInstancesTopicConnection() != null)
+                            {
+                                currentDetails.setConnection("Cohort Instances Topic", cohortConfig.getCohortOMRSInstancesTopicConnection());
+                            }
+
+                            if (cohortConfig.getCohortOMRSTopicConnection() != null)
+                            {
+                                currentDetails.setConnection("Cohort OMRS Topic (deprecated)", cohortConfig.getCohortOMRSTopicConnection());
+                            }
+                        }
+                    }
+                }
+
+                if (configuration.getAccessServicesConfig() != null)
+                {
+                    for (AccessServiceConfig accessServiceConfig : configuration.getAccessServicesConfig())
+                    {
+                        if (accessServiceConfig != null)
+                        {
+                            OMAGServiceDetails currentDetails = serviceDetailsMap.get(accessServiceConfig.getAccessServiceFullName());
+
+                            if (currentDetails == null)
+                            {
+                                currentDetails = new OMAGServiceDetails(accessServiceConfig.getAccessServiceFullName());
+                            }
+
+                            currentDetails.setServiceOptions(accessServiceConfig.getAccessServiceOptions());
+                            currentDetails.setConnection("InTopic", accessServiceConfig.getAccessServiceInTopic());
+                            currentDetails.setConnection("OutTopic", accessServiceConfig.getAccessServiceInTopic());
+
+                            serviceDetailsMap.put(accessServiceConfig.getAccessServiceFullName(), currentDetails);
+                        }
+                    }
+                }
+
+                if (configuration.getEngineHostServicesConfig() != null)
+                {
+                    OMAGServiceDetails currentDetails = serviceDetailsMap.get(GovernanceServicesDescription.ENGINE_HOST_SERVICES.getServiceName());
+
+                    if (currentDetails == null)
+                    {
+                        currentDetails = new OMAGServiceDetails(GovernanceServicesDescription.ENGINE_HOST_SERVICES.getServiceName());
+                    }
+
+                    currentDetails.setPartnerService(configuration.getEngineHostServicesConfig().getOMAGServerName(),
+                                                     configuration.getEngineHostServicesConfig().getOMAGServerPlatformRootURL(),
+                                                     AccessServiceDescription.GOVERNANCE_ENGINE_OMAS.getAccessServiceFullName());
+
+                    if (configuration.getEngineHostServicesConfig().getEngineServiceConfigs() != null)
+                    {
+                        for (EngineServiceConfig engineServiceConfig : configuration.getEngineHostServicesConfig().getEngineServiceConfigs())
+                        {
+                            if (engineServiceConfig != null)
+                            {
+                                OMAGServiceDetails nestedDetails = serviceDetailsMap.get(engineServiceConfig.getEngineServiceFullName());
+
+                                if (nestedDetails == null)
+                                {
+                                    nestedDetails = new OMAGServiceDetails(engineServiceConfig.getEngineServiceFullName());
+                                }
+
+                                nestedDetails.setServiceOptions(engineServiceConfig.getEngineServiceOptions());
+                                nestedDetails.setPartnerService(engineServiceConfig.getOMAGServerName(),
+                                                                engineServiceConfig.getOMAGServerPlatformRootURL(),
+                                                                engineServiceConfig.getEngineServicePartnerOMAS());
+
+                                if (engineServiceConfig.getEngines() != null)
+                                {
+                                    for (EngineConfig engineConfig : engineServiceConfig.getEngines())
+                                    {
+                                        if (engineConfig != null)
+                                        {
+                                            OMAGServiceDetails engineServiceDetails = new OMAGServiceDetails(engineConfig.getEngineQualifiedName());
+
+                                            engineServiceDetails.setServiceId(engineConfig.getEngineId());
+                                            engineServiceDetails.setServiceUserId(engineConfig.getEngineUserId());
+
+                                            nestedDetails.addNestedService(engineConfig.getEngineQualifiedName(), engineServiceDetails);
+                                        }
+                                    }
+                                }
+
+                                serviceDetailsMap.put(engineServiceConfig.getEngineServiceFullName(), currentDetails);
+                            }
+                        }
+                    }
+                }
+
+                if (configuration.getIntegrationServicesConfig() != null)
+                {
+                    for (IntegrationServiceConfig integrationServiceConfig : configuration.getIntegrationServicesConfig())
+                    {
+                        if (integrationServiceConfig != null)
+                        {
+                            OMAGServiceDetails currentDetails = serviceDetailsMap.get(integrationServiceConfig.getIntegrationServiceFullName());
+
+                            if (currentDetails == null)
+                            {
+                                currentDetails = new OMAGServiceDetails(integrationServiceConfig.getIntegrationServiceFullName());
+                            }
+
+                            currentDetails.setServiceOptions(integrationServiceConfig.getIntegrationServiceOptions());
+                            currentDetails.setPartnerService(integrationServiceConfig.getOMAGServerName(),
+                                                             integrationServiceConfig.getOMAGServerPlatformRootURL(),
+                                                             integrationServiceConfig.getIntegrationServicePartnerOMAS());
+
+                            if (integrationServiceConfig.getIntegrationConnectorConfigs() != null)
+                            {
+                                for (IntegrationConnectorConfig connectorConfig : integrationServiceConfig.getIntegrationConnectorConfigs())
+                                {
+                                    if (connectorConfig != null)
+                                    {
+                                        String nestedServiceName = "Integration Connector: " + connectorConfig.getConnectorName();
+
+                                        OMAGServiceDetails connectorConfigDetails = new OMAGServiceDetails(nestedServiceName);
+
+                                        connectorConfigDetails.setServiceUserId(connectorConfig.getConnectorUserId());
+                                        connectorConfigDetails.setServiceId(connectorConfig.getConnectorId());
+                                        connectorConfigDetails.setConnection("Integration Connector Implementation", connectorConfig.getConnection());
+
+                                        currentDetails.addNestedService(nestedServiceName, connectorConfigDetails);
+                                    }
+                                }
+                            }
+
+                            serviceDetailsMap.put(integrationServiceConfig.getIntegrationServiceFullName(), currentDetails);
+                        }
+                    }
+                }
+
+                if (configuration.getViewServicesConfig() != null)
+                {
+                    for (ViewServiceConfig viewServiceConfig : configuration.getViewServicesConfig())
+                    {
+                        if (viewServiceConfig != null)
+                        {
+                            OMAGServiceDetails currentDetails = serviceDetailsMap.get(viewServiceConfig.getViewServiceFullName());
+
+                            if (currentDetails == null)
+                            {
+                                currentDetails = new OMAGServiceDetails(viewServiceConfig.getViewServiceFullName());
+                            }
+
+                            currentDetails.setServiceOptions(viewServiceConfig.getViewServiceOptions());
+                            currentDetails.setPartnerService(viewServiceConfig.getOMAGServerName(),
+                                                             viewServiceConfig.getOMAGServerPlatformRootURL(),
+                                                             null);
+
+                            serviceDetailsMap.put(viewServiceConfig.getViewServiceFullName(), currentDetails);
+                        }
+                    }
+                }
+
+                if (configuration.getDataEngineProxyConfig() != null)
+                {
+                    OMAGServiceDetails currentDetails = serviceDetailsMap.get(GovernanceServicesDescription.DATA_ENGINE_PROXY_SERVICES.getServiceName());
+
+                    if (currentDetails == null)
+                    {
+                        currentDetails = new OMAGServiceDetails(GovernanceServicesDescription.DATA_ENGINE_PROXY_SERVICES.getServiceName());
+                    }
+
+                    currentDetails.setPartnerService(configuration.getDataEngineProxyConfig().getAccessServiceServerName(),
+                                                     configuration.getDataEngineProxyConfig().getAccessServiceRootURL(),
+                                                     AccessServiceDescription.DATA_ENGINE_OMAS.getAccessServiceFullName());
+
+                    serviceDetailsMap.put(GovernanceServicesDescription.DATA_ENGINE_PROXY_SERVICES.getServiceName(),
+                                          currentDetails);
+                }
+
+                if (configuration.getOpenLineageServerConfig() != null)
+                {
+                    OMAGServiceDetails currentDetails = serviceDetailsMap.get(GovernanceServicesDescription.OPEN_LINEAGE_SERVICES.getServiceName());
+
+                    if (currentDetails == null)
+                    {
+                        currentDetails = new OMAGServiceDetails(GovernanceServicesDescription.OPEN_LINEAGE_SERVICES.getServiceName());
+                    }
+
+                    currentDetails.setPartnerService(configuration.getOpenLineageServerConfig().getAccessServiceConfig().getServerName(),
+                                                     configuration.getOpenLineageServerConfig().getAccessServiceConfig().getServerPlatformUrlRoot(),
+                                                     AccessServiceDescription.ASSET_LINEAGE_OMAS.getAccessServiceFullName());
+
+                    serviceDetailsMap.put(GovernanceServicesDescription.OPEN_LINEAGE_SERVICES.getServiceName(),
+                                          currentDetails);
+                }
+            }
+        }
+
+
+        /**
+         * The server type show where the server fits in the architecture.
+         *
+         * @param serverType name of the server type
+         */
+        void setServerType(String serverType)
+        {
+            this.serverType = serverType;
+        }
+
+
+        /**
+         * Is the server stopped, starting or running?
+         *
+         * @param serverActiveStatus what is the server status (null if not running)
+         */
+        void setServerActiveStatus(ServerActiveStatus serverActiveStatus)
+        {
+            this.serverActiveStatus = serverActiveStatus;
+        }
+
+
+        /**
+         * The time that the server last started.
+         *
+         * @param serverStartTime date/time or null
+         */
+        void setServerStartTime(Date serverStartTime)
+        {
+            this.serverStartTime = serverStartTime;
+        }
+
+
+        /**
+         * The time that the server shut down - will be null if server started or never run.
+         *
+         * @param serverEndTime date/time or null
+         */
+        void setServerEndTime(Date serverEndTime)
+        {
+            this.serverEndTime = serverEndTime;
+        }
+
+
+        /**
+         * This lists the times that the server has run on the platform instance.
+         *
+         * @param serverHistory server history list
+         */
+        void setServerHistory(List<OMAGServerInstanceHistory> serverHistory)
+        {
+            this.serverHistory = serverHistory;
+        }
+
+
+        /**
+         * List the services that are currently running - null if the server is not running.
+         *
+         * @param services list of server status
+         */
+        void setServices(List<OMAGServerServiceStatus> services)
+        {
+            if (services != null)
+            {
+                for (OMAGServerServiceStatus serviceStatus : services)
+                {
+                    OMAGServiceDetails currentDetails = serviceDetailsMap.get(serviceStatus.getServiceName());
+
+                    if (currentDetails == null)
+                    {
+                        currentDetails = new OMAGServiceDetails(serviceStatus.getServiceName());
+                    }
+
+                    currentDetails.setServiceStatus(serviceStatus.getServiceStatus());
+
+                    serviceDetailsMap.put(serviceStatus.getServiceName(), currentDetails);
+                }
+            }
+        }
+
+
+        /**
+         * Return the cohort details for the named cohort.
+         *
+         * @param cohortName name of the cohort.
+         *
+         * @return corresponding details
+         */
+        OMAGCohortDetails getCohortDetails(String cohortName)
+        {
+            OMAGCohortDetails cohortDetails = cohortDetailsMap.get(cohortName);
+
+            if (cohortDetails == null)
+            {
+                cohortDetails = new OMAGCohortDetails(cohortName);
+
+                cohortDetailsMap.put(cohortName, cohortDetails);
+            }
+
+            return cohortDetails;
+        }
+
+        /**
+         * Output the details that have been collected about the server.
+         *
+         * @param indentLevel amount of white space to add before each line of the report
+         */
+        void printServer(int indentLevel) throws IOException
+        {
+            report.printReportSubheading(indentLevel,"Server: " +  serverName);
+
+            int detailIndentLevel = indentLevel + 1;
+
+            report.printReportLine(detailIndentLevel, "Type", serverType);
+
+            if (configuration != null)
+            {
+                report.printReportLine(detailIndentLevel, "Description", configuration.getLocalServerDescription());
+                report.printReportLine(detailIndentLevel, "UserId", configuration.getLocalServerUserId());
+
+                if (configuration.getServerSecurityConnection() != null)
+                {
+                    report.printConnection(detailIndentLevel, "Security Connector", configuration.getServerSecurityConnection());
+                }
+
+                if (configuration.getRepositoryServicesConfig() != null)
+                {
+                    if (configuration.getRepositoryServicesConfig().getLocalRepositoryConfig() != null)
+                    {
+                        report.printReportSubheading(detailIndentLevel,"Local Repository");
+
+                        if (configuration.getRepositoryServicesConfig().getLocalRepositoryConfig().getLocalRepositoryMode() != null)
+                        {
+                            report.printReportLine(detailIndentLevel + 1,
+                                                   "Local Repository Mode",
+                                                   configuration.getRepositoryServicesConfig().getLocalRepositoryConfig().getLocalRepositoryMode().getName());
+                        }
+
+                        if (configuration.getRepositoryServicesConfig().getLocalRepositoryConfig().getLocalRepositoryLocalConnection() != null)
+                        {
+                            report.printConnection(detailIndentLevel + 1,
+                                                   "Local Repository Connector",
+                                                   configuration.getRepositoryServicesConfig().getLocalRepositoryConfig().getLocalRepositoryLocalConnection());
+                        }
+
+                        if (configuration.getRepositoryServicesConfig().getLocalRepositoryConfig().getEventMapperConnection() != null)
+                        {
+                            report.printConnection(detailIndentLevel + 1,
+                                                   "Local Repository Event Mapper Connector",
+                                                   configuration.getRepositoryServicesConfig().getLocalRepositoryConfig().getEventMapperConnection());
+                        }
+
+                        if (configuration.getRepositoryServicesConfig().getLocalRepositoryConfig().getLocalRepositoryRemoteConnection() != null)
+                        {
+                            report.printConnection(detailIndentLevel + 1,
+                                                   "Local Repository Remote Connector",
+                                                   configuration.getRepositoryServicesConfig().getLocalRepositoryConfig().getLocalRepositoryRemoteConnection());
+                        }
+                    }
+                }
+            }
+
+            if (serverStartTime != null)
+            {
+                report.printReportLine(detailIndentLevel,"Last Start Time", serverStartTime.toString());
+            }
+
+            if (serverEndTime != null)
+            {
+                report.printReportLine(detailIndentLevel,"Last End Time", serverEndTime.toString());
+            }
+
+            if ((serverActiveStatus != null) && (serverActiveStatus != ServerActiveStatus.UNKNOWN))
+            {
+                report.printReportLine(detailIndentLevel,"Server Active Status", serverActiveStatus.getName());
+            }
+
+            if (serverHistory != null)
+            {
+                report.printReportSubheading(detailIndentLevel,"History");
+
+                for (OMAGServerInstanceHistory instanceHistory : serverHistory)
+                {
+                    if (instanceHistory.getStartTime() != null)
+                    {
+                        report.printReportLine(detailIndentLevel + 1,"Start Time", instanceHistory.getStartTime().toString());
+                    }
+                    if (instanceHistory.getEndTime() != null)
+                    {
+                        report.printReportLine(detailIndentLevel + 1,"End Time", instanceHistory.getEndTime().toString());
+                    }
+                }
+            }
+
+            report.printReportSubheading(detailIndentLevel,"Services");
+
+            for (OMAGServiceDetails serviceDetails : serviceDetailsMap.values())
+            {
+                serviceDetails.printService(detailIndentLevel + 1);
+            }
+
+            if (! cohortDetailsMap.isEmpty())
+            {
+                report.printReportSubheading(detailIndentLevel, "Cohorts");
+
+                for (OMAGCohortDetails cohortDetails : cohortDetailsMap.values())
+                {
+                    cohortDetails.printCohort(detailIndentLevel + 1);
+                }
+            }
+        }
+
+
+        /**
+         * OMAGServiceDetails caches details about a particular service.
+         */
+        private class OMAGServiceDetails
+        {
+            private String                          serviceName;
+            private String                          serviceId          = null;
+            private String                          serviceUserId      = null;
+            private ServerActiveStatus              serviceStatus      = ServerActiveStatus.UNKNOWN;
+            private Map<String, Object>             serviceOptions     = null;
+            private String                          partnerServerName  = null;
+            private String                          partnerURLRoot     = null;
+            private String                          partnerServiceName = null;
+            private Map<String, Connection>         connectors         = null;
+            private Map<String, OMAGServiceDetails> nestedServices     = null;
+
+
+            /**
+             * Constructor requires the service name.
+             *
+             * @param serviceName display name of the service.
+             */
+            OMAGServiceDetails(String serviceName)
+            {
+                this.serviceName = serviceName;
+            }
+
+
+            /**
+             * Set up the unique identifier for the service.
+             *
+             * @param serviceId string Id
+             */
+            void setServiceId(String serviceId)
+            {
+                this.serviceId = serviceId;
+            }
+
+
+            /**
+             * Set up the user Id assigned to this service.
+             *
+             * @param serviceUserId user Id
+             */
+            void setServiceUserId(String serviceUserId)
+            {
+                this.serviceUserId = serviceUserId;
+            }
+
+
+            /**
+             * Set up the current status.
+             *
+             * @param serviceStatus server instance status enum value
+             */
+            void setServiceStatus(ServerActiveStatus serviceStatus)
+            {
+                this.serviceStatus = serviceStatus;
+            }
+
+
+            /**
+             * Save the service options as printable strings.
+             *
+             * @param serviceOptions configured service options
+             */
+            void setServiceOptions(Map<String, Object> serviceOptions)
+            {
+                this.serviceOptions = serviceOptions;
+            }
+
+
+            /**
+             * Set up details of the partner service that this service is dependent on.
+             *
+             * @param partnerServerName name of the partner server
+             * @param partnerURLRoot URL for the hosting platform
+             * @param partnerServiceName service that is called in the partner server
+             */
+            void setPartnerService(String partnerServerName,
+                                   String partnerURLRoot,
+                                   String partnerServiceName)
+            {
+                this.partnerServerName = partnerServerName;
+                this.partnerURLRoot = partnerURLRoot;
+                this.partnerServiceName = partnerServiceName;
+            }
+
+
+            /**
+             * Add details of a connector configured for this service.
+             *
+             * @param connectorName name/label for the connection
+             * @param connection configuration information
+             */
+            void setConnection(String     connectorName,
+                               Connection connection)
+            {
+                if (connection != null)
+                {
+                    if (connectors == null)
+                    {
+                        connectors = new HashMap<>();
+                    }
+
+                    Connection existingConnection = connectors.put(connectorName, connection);
+
+                    if (existingConnection != null)
+                    {
+                        System.out.println("Error: two connectors of the same name: " + connectorName + " in service: " + serviceName);
+                        System.out.println("       existing connection: " + existingConnection);
+                        System.out.println("       new connection: " + connection);
+                    }
+                }
+            }
+
+
+            /**
+             * Add details of a service that is nested in this service.
+             *
+             * @param serviceName nested service name
+             * @param serviceDetails description of the nested service
+             */
+            void addNestedService(String             serviceName,
+                                  OMAGServiceDetails serviceDetails)
+            {
+                if (nestedServices == null)
+                {
+                    nestedServices = new HashMap<>();
+                }
+
+                OMAGServiceDetails existingService = nestedServices.put(serviceName, serviceDetails);
+
+                if (existingService != null)
+                {
+                    System.out.println("Error: two nested services of same name: " + serviceName + " in service: " + this.serviceName);
+                    System.out.println("       existing nested service: " + existingService);
+                    System.out.println("       new nested service: " + serviceDetails);
+                }
+            }
+
+
+            /**
+             * Print out details of the service that have been collected from the different APIs.
+             *
+             * @param indentLevel spacing for the service
+             *
+             * @throws IOException problem writing to the report
+             */
+            void printService(int indentLevel) throws IOException
+            {
+                report.printReportSubheading(indentLevel, "Service: " + serviceName);
+
+                int detailIndentLevel = indentLevel + 1;
+
+                if (serviceId != null)
+                {
+                    report.printReportLine(detailIndentLevel, "Service Id", serviceId);
+                }
+
+                if (serviceUserId != null)
+                {
+                    report.printReportLine(detailIndentLevel, "Service UserId", serviceUserId);
+                }
+
+                if ((serviceStatus != null) && (serviceStatus != ServerActiveStatus.UNKNOWN))
+                {
+                    report.printReportLine(detailIndentLevel, "Service Status", serviceStatus.getName());
+                }
+
+                if (partnerServerName != null)
+                {
+                    report.printReportSubheading(detailIndentLevel, "Partner Service:");
+                    report.printReportLine(detailIndentLevel + 1, "Partner Server", partnerServerName);
+                    report.printReportLine(detailIndentLevel + 1, "Partner URL root", partnerURLRoot);
+                    report.printReportLine(detailIndentLevel + 1, "Calling Service Name", partnerServiceName);
+                }
+
+                if (serviceOptions != null)
+                {
+                    report.printReportSubheading(detailIndentLevel, "Service Options");
+                    for (String optionName : serviceOptions.keySet())
+                    {
+                        if (optionName != null)
+                        {
+                            report.printReportLine(detailIndentLevel + 1, optionName, serviceOptions.get(optionName).toString());
+                        }
+                    }
+                }
+
+                if (nestedServices != null)
+                {
+                    report.printReportSubheading(detailIndentLevel, "Nested Services");
+
+                    for (OMAGServiceDetails nestedService : nestedServices.values())
+                    {
+                        if (nestedService != null)
+                        {
+                            nestedService.printService(detailIndentLevel + 1);
+                        }
+                    }
+                }
+
+                if (connectors != null)
+                {
+                    if (connectors.size() > 1)
+                    {
+                        report.printReportSubheading(detailIndentLevel, "Connectors");
+                        detailIndentLevel = detailIndentLevel + 1;
+                    }
+
+                    for (String connectorName : connectors.keySet())
+                    {
+                        report.printConnection(detailIndentLevel, connectorName, connectors.get(connectorName));
+                    }
+                }
+            }
+        }
+
+
+        /**
+         * OMAGCohortDetails caches details about a particular cohort.
+         */
+        private class OMAGCohortDetails
+        {
+            private String                   cohortName;
+            private CohortConnectionStatus   connectionStatus    = null;
+            private Map<String, Connection>  connectors          = null;
+            private MemberRegistration       localRegistration   = null;
+            private List<MemberRegistration> remoteRegistrations = null;
+
+
+            /**
+             * Constructor requires the cohort name.
+             *
+             * @param cohortName display name of the cohort.
+             */
+            OMAGCohortDetails(String cohortName)
+            {
+                this.cohortName = cohortName;
+            }
+
+
+            /**
+             * Set up the current status of the server's connection to the cohort.
+             *
+             * @param connectionStatus enum
+             */
+            void setConnectionStatus(CohortConnectionStatus connectionStatus)
+            {
+                this.connectionStatus = connectionStatus;
+            }
+
+
+            /**
+             * Add details of a connector configured for this cohort.
+             *
+             * @param connectorName name/label for the connection
+             * @param connection configuration information
+             */
+            void setConnection(String     connectorName,
+                               Connection connection)
+            {
+                if (connection != null)
+                {
+                    if (connectors == null)
+                    {
+                        connectors = new HashMap<>();
+                    }
+
+                    Connection existingConnection = connectors.put(connectorName, connection);
+
+                    if (existingConnection != null)
+                    {
+                        System.out.println("Error: two connectors of the same name: " + connectorName + " in service: " + cohortName);
+                        System.out.println("       existing connection: " + existingConnection);
+                        System.out.println("       new connection: " + connection);
+                    }
+                }
+            }
+
+
+            /**
+             * Set up information about the server's information that it sends out when it registers with a cohort.
+             *
+             * @param localRegistration local registration details
+             */
+            void setLocalRegistration(MemberRegistration localRegistration)
+            {
+                this.localRegistration = localRegistration;
+            }
+
+
+            /**
+             * Set up the list of responses that this server has received from the other members of the cohort.
+             *
+             * @param remoteRegistrations list of responses from remote cohort members
+             */
+            void setRemoteRegistrations(List<MemberRegistration> remoteRegistrations)
+            {
+                this.remoteRegistrations = remoteRegistrations;
+            }
+
+
+            /**
+             * Print out details of the cohort that have been collected from the different APIs.
+             *
+             * @param indentLevel spacing for the cohort content
+             *
+             * @throws IOException problem writing to the report
+             */
+            void printCohort(int indentLevel) throws IOException
+            {
+                report.printReportSubheading(indentLevel, "Cohort: " + cohortName);
+
+                int detailIndentLevel = indentLevel + 1;
+
+                if (connectionStatus != null)
+                {
+                    report.printReportLine(detailIndentLevel, "Cohort Connection Status", connectionStatus.getStatusName());
+                }
+
+                if (connectors != null)
+                {
+                    if (connectors.size() > 1)
+                    {
+                        report.printReportSubheading(detailIndentLevel, "Cohort Connectors");
+                        detailIndentLevel = detailIndentLevel + 1;
+                    }
+
+                    for (String connectorName : connectors.keySet())
+                    {
+                        report.printConnection(detailIndentLevel, connectorName, connectors.get(connectorName));
+                    }
+                }
+
+                if (localRegistration != null)
+                {
+                    report.printReportSubheading(detailIndentLevel, "Local registration to " + cohortName);
+
+                    report.printReportLine(detailIndentLevel + 1, "Metadata Collection Id", localRegistration.getMetadataCollectionId());
+                    report.printReportLine(detailIndentLevel + 1, "Metadata Collection Name", localRegistration.getMetadataCollectionName());
+
+                    if (localRegistration.getRegistrationTime() != null)
+                    {
+                        report.printReportLine(detailIndentLevel + 1, "First registration time with cohort", localRegistration.getRegistrationTime().toString());
+                    }
+                }
+
+                if (remoteRegistrations != null)
+                {
+                    report.printReportSubheading(detailIndentLevel, "Registrations received from members of " + cohortName);
+
+                    for (MemberRegistration remoteRegistration : remoteRegistrations)
+                    {
+                        if (remoteRegistration != null)
+                        {
+                            report.printReportSubheading(detailIndentLevel + 1, "Registration from " + remoteRegistration.getServerName());
+
+                            report.printReportLine(detailIndentLevel + 2, "Metadata Collection Id", localRegistration.getMetadataCollectionId());
+                            report.printReportLine(detailIndentLevel + 2, "Metadata Collection Name", localRegistration.getMetadataCollectionName());
+                            report.printReportLine(detailIndentLevel + 2, "Server Type", localRegistration.getServerType());
+                            report.printReportLine(detailIndentLevel + 2, "Organization", localRegistration.getOrganizationName());
+
+                            if (remoteRegistration.getRegistrationTime() != null)
+                            {
+                                report.printReportLine(detailIndentLevel + 2, "First registration time with this member", remoteRegistration.getRegistrationTime().toString());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Main program that controls the operation of the platform report.  The parameters are passed space separated.
+     * The platforms URL root must be passed as parameter 1.  The other parameters are used to override the
+     * report's default values.
+     *
+     * @param args 1. service platform URL root, 2. client userId, 3. server name,
+     */
+    public static void main(String[] args)
+    {
+        String  serverName = null; // means all servers
+        String  platformURLRoot = "https://localhost:9443";
+        String  clientUserId = "garygeeke";
+
+        if (args.length > 0)
+        {
+            platformURLRoot = args[0];
+        }
+
+        if (args.length > 1)
+        {
+            clientUserId = args[1];
+        }
+
+        if (args.length > 2)
+        {
+            serverName = args[2];
+        }
+
+        System.out.println("===============================");
+        System.out.println("OMAG Server Platform Report:    " + new Date().toString());
+        System.out.println("===============================");
+        System.out.println("Running against platform: " + platformURLRoot);
+        if (serverName != null)
+        {
+            System.out.println("Focused on server: " + serverName);
+        }
+        System.out.println("Using userId: " + clientUserId);
+        System.out.println();
+
+        HttpHelper.noStrictSSLIfConfigured();
+
+        try
+        {
+            EgeriaPlatformReport report = new EgeriaPlatformReport(serverName, platformURLRoot, clientUserId);
+
+            report.run();
+        }
+        catch (Exception  error)
+        {
+            System.out.println("Exception: " + error.getClass().getName() + " with message " + error.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/egeria-platform-report/src/main/resources/logback-test.xml
+++ b/egeria-platform-report/src/main/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="OFF">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/egeria-platform-report/src/main/resources/logback.xml
+++ b/egeria-platform-report/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="OFF">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/egeria-report-utilities/README.md
+++ b/egeria-report-utilities/README.md
@@ -1,0 +1,31 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+# Egeria Platform Report (egeria-platform-report)
+
+The Egeria platform report is passed a platform URL root (and optional server name) that
+it uses to query the operational status of the platform.  For example:
+
+* Which *version* of Egeria is running
+* Which *Platform Metadata Security Connector* is configured.
+* Which *Configuration Document Store Connector* is configured.
+* Which *Registered Services* are installed.
+* Which *OMAG Servers* are visible to the platform.
+   * For each configured server
+      * What type of server is it and its description
+      * Which services are configured
+      * Which connectors are configured and whether they are installed and usable on the platform
+      * Which cohorts are configured for the server to join (if applicable)
+   * For each known server (ie has run at least once since the platform started):
+      * The time when it has been running on the platform
+   * If the server is still running the following details are added
+      * The running status of its services
+      * The report from the audit log describing the statistics from each component
+      * the registration status of the server with its cohorts (if applicable)
+      * the status of its engines/connectors (if applicable)
+
+
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the Egeria project.

--- a/egeria-report-utilities/pom.xml
+++ b/egeria-report-utilities/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>egeria-dev-projects</artifactId>
+        <groupId>org.odpi.egeria</groupId>
+        <version>3.6-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Egeria Report Utilities</name>
+    <description>
+        Provide methods to display text to the screen and creates a markdown equivalent report file.
+    </description>
+
+    <artifactId>egeria-report-utilities</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-connector-framework</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>ffdc-services</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/egeria-report-utilities/src/main/java/org/odpi/openmetadata/devprojects/reports/EgeriaReport.java
+++ b/egeria-report-utilities/src/main/java/org/odpi/openmetadata/devprojects/reports/EgeriaReport.java
@@ -1,0 +1,253 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.reports;
+
+
+
+import org.odpi.openmetadata.commonservices.ffdc.rest.RegisteredOMAGService;
+import org.odpi.openmetadata.frameworks.connectors.properties.beans.Connection;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+
+/**
+ * EgeriaReport provides utilities to allow a report to print to the screen and create
+ * a markdown file at the same time.
+ */
+public class EgeriaReport
+{
+    private FileOutputStream fileOutStream;
+
+
+    /**
+     * Work out how many spaces to indent a line in the report.  This is used in the stdout report/
+     *
+     * @param indentLevel required indentation
+     * @return string of blanks representing the indentation
+     */
+    public String getSpaceIndent(int indentLevel)
+    {
+        StringBuilder indent = new StringBuilder();
+
+        for (int i=0; i<indentLevel; i++)
+        {
+            indent.append("   ");
+        }
+
+        return indent.toString();
+    }
+
+
+    /**
+     * Set up the heading hash characters that represent the heading level of the markdown document.
+     *
+     * @param indentLevel required heading level
+     * @return string to prepend to the heading text
+     */
+    public String getHeadingLevel(int indentLevel)
+    {
+        if (indentLevel > 5)
+        {
+            /*
+             * Indent level is more than mark down supports so need to be creative.
+             */
+            StringBuilder indent = new StringBuilder("###### ");
+
+            for (int i = 5; i < indentLevel; i++)
+            {
+                indent.append("==");
+            }
+
+            return indent.append("> ").toString();
+        }
+        else
+        {
+            StringBuilder indent = new StringBuilder("#");
+
+            for (int i = 0; i < indentLevel; i++)
+            {
+                indent.append("#");
+            }
+
+            return indent.append(" ").toString();
+        }
+    }
+
+
+    /**
+     * Prints out the text for a subheading the report.
+     *
+     * @param indentLevel number of spaces to indent
+     * @param platformURLRoot location of the platform
+     * @throws IOException problem writing file
+     */
+    public  void printReportTitle(int    indentLevel,
+                                  String platformURLRoot) throws IOException
+    {
+        final String reportTitle     = "Platform report for: ";
+
+        System.out.println(getSpaceIndent(indentLevel) + reportTitle + platformURLRoot);
+
+        String reportString = getHeadingLevel(indentLevel) + reportTitle  + platformURLRoot + "\n\n";
+
+        fileOutStream.write(reportString.getBytes());
+    }
+
+
+    /**
+     * Prints out the text for a subheading the report.
+     *
+     * @param indentLevel number of spaces to indent
+     * @param titleText text to be included in the subheading
+     * @throws IOException problem writing file
+     */
+    public  void printReportSubheading(int    indentLevel,
+                                       String titleText) throws IOException
+    {
+        System.out.println(getSpaceIndent(indentLevel) + titleText);
+
+        String reportString = getHeadingLevel(indentLevel) + titleText + "\n";
+
+        fileOutStream.write(reportString.getBytes());
+    }
+
+
+    /**
+     * Prints out the text for a single line of the report.
+     *
+     * @param indentLevel number of spaces to indent
+     * @param elementLabel label of the element
+     * @param elementText value of the element
+     * @throws IOException problem writing file
+     */
+    public  void printReportLine(int    indentLevel,
+                                 String elementLabel,
+                                 String elementText) throws IOException
+    {
+        if (elementText == null)
+        {
+            System.out.println(getSpaceIndent(indentLevel) + elementLabel + ": " + "<null>");
+
+            String reportString = "* **" + elementLabel + "**: " + "*null*" + "\n";
+
+            fileOutStream.write(reportString.getBytes());
+        }
+        else
+        {
+            System.out.println(getSpaceIndent(indentLevel) + elementLabel + ": " + elementText);
+
+            String reportString = "* **" + elementLabel + "**: " + elementText + "\n";
+
+            fileOutStream.write(reportString.getBytes());
+        }
+
+    }
+
+
+    /**
+     * Print out details of a connection.
+     *
+     * @param detailIndentLevel how many spaces to include
+     * @param elementLabel name of the connector
+     * @param connection connector's connection
+     * @throws IOException problem writing report
+     */
+    public  void printConnection(int        detailIndentLevel,
+                                 String     elementLabel,
+                                 Connection connection) throws IOException
+    {
+        if (connection == null)
+        {
+            printReportLine(detailIndentLevel, elementLabel, null);
+        }
+        else
+        {
+            printReportSubheading(detailIndentLevel, elementLabel);
+
+            if (connection.getConnectorType() == null)
+            {
+                printReportLine(detailIndentLevel + 1, "Implementation", null);
+            }
+            else
+            {
+                printReportLine(detailIndentLevel + 1, "Implementation", connection.getConnectorType().getConnectorProviderClassName());
+            }
+
+            if (connection.getEndpoint() == null)
+            {
+                printReportLine(detailIndentLevel + 1, "Location", null);
+            }
+            else
+            {
+                printReportLine(detailIndentLevel + 1, "Location", connection.getEndpoint().getAddress());
+            }
+
+            if (connection.getConfigurationProperties() != null)
+            {
+                printReportLine(detailIndentLevel + 1, "Configuration Properties", connection.getConfigurationProperties().toString());
+            }
+        }
+    }
+
+
+    /**
+     * Print out the details of a registered service.
+     *
+     * @param indentLevel spaces needed in the report line
+     * @param registeredOMAGServices list of registered services
+     * @throws IOException problem writing the report
+     */
+    public  void printRegisteredServices(int                         indentLevel,
+                                         List<RegisteredOMAGService> registeredOMAGServices) throws IOException
+    {
+        if (registeredOMAGServices != null)
+        {
+            for (RegisteredOMAGService serviceDescription : registeredOMAGServices)
+            {
+                printReportLine(indentLevel, serviceDescription.getServiceName(), serviceDescription.getServiceDescription());
+            }
+        }
+    }
+
+
+    /**
+     * Set up the parameters for the sample.
+     *
+     * @param reportFileName name of file to wrote markdown content to
+     * @throws IOException problem writing file
+     */
+    public EgeriaReport(String reportFileName) throws IOException
+    {
+        final String licenseString   = "<!-- SPDX-License-Identifier: CC-BY-4.0 -->\n";
+        final String copyrightString = "<!-- Copyright Contributors to the Egeria project. -->\n\n";
+
+        File reportFile = new File(reportFileName);
+
+        if (reportFile.exists())
+        {
+            if (! reportFile.delete())
+            {
+                System.out.println("Unable to delete report file: " + reportFileName);
+            }
+        }
+
+        fileOutStream = new FileOutputStream(reportFile);
+
+        fileOutStream.write(licenseString.getBytes());
+        fileOutStream.write(copyrightString.getBytes());
+    }
+
+
+    /**
+     * This adds the last line to the report.
+     */
+    public void closeReport() throws IOException
+    {
+        final String snippetString   = "\n--8<-- \"snippets/abbr.md\"";
+
+        fileOutStream.write(snippetString.getBytes());
+    }
+}

--- a/egeria-report-utilities/src/main/resources/logback.xml
+++ b/egeria-report-utilities/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="OFF">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/event-display-audit-log-connector/README.md
+++ b/event-display-audit-log-connector/README.md
@@ -1,0 +1,18 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+
+# Event Display Audit Log Connector (event-display-audit-log-connector)
+
+The *event display audit log connector* is an *Audit Log Store Connector* that outputs
+the content of events flowing between the different servers in the open metadata ecosystem.
+
+By default event contents are not displayed on the console because they may contain sensitive
+content.  However, the event content is stored in the *additionalInformation*
+field of the log record.  This connector detects log record that describe events and
+outputs the event content as part of displaying the message.
+
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the Egeria project.

--- a/event-display-audit-log-connector/pom.xml
+++ b/event-display-audit-log-connector/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>egeria-dev-projects</artifactId>
+        <groupId>org.odpi.egeria</groupId>
+        <version>3.6-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Event Display Audit Log Store Connector</name>
+    <description>
+        Outputs the event payloads on the audit log.
+    </description>
+
+    <artifactId>event-display-audit-log-connector</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-connector-framework</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>repository-services-apis</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/event-display-audit-log-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors.auditlog.eventdisplay/EventDisplayAuditLogStoreConnector.java
+++ b/event-display-audit-log-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors.auditlog.eventdisplay/EventDisplayAuditLogStoreConnector.java
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.connectors.auditlog.eventdisplay;
+
+import org.odpi.openmetadata.repositoryservices.auditlog.OMRSAuditLogRecordSeverity;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.auditlogstore.OMRSAuditLogRecord;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.auditlogstore.OMRSAuditLogStoreConnectorBase;
+import org.odpi.openmetadata.repositoryservices.ffdc.exception.InvalidParameterException;
+
+/**
+ * EventDisplayAuditLogStoreConnector provides a connector implementation for a console (stdout) audit log.
+ */
+public class EventDisplayAuditLogStoreConnector extends OMRSAuditLogStoreConnectorBase
+{
+    /**
+     * Default constructor used by the connector provider.
+     */
+    public EventDisplayAuditLogStoreConnector()
+    {
+    }
+
+
+    /**
+     * Store the audit log record in the audit log store.
+     *
+     * @param logRecord  log record to store
+     * @return unique identifier assigned to the log record
+     * @throws InvalidParameterException indicates that the logRecord parameter is invalid.
+     */
+    @Override
+    public String storeLogRecord(OMRSAuditLogRecord logRecord) throws InvalidParameterException
+    {
+        final String methodName = "storeLogRecord";
+
+        super.validateLogRecord(logRecord, methodName);
+
+        if (OMRSAuditLogRecordSeverity.EVENT.getName().equals(logRecord.getSeverity()))
+        {
+            if (logRecord.getAdditionalInformation() != null)
+            {
+                System.out.println(logRecord.getTimeStamp() + " " + logRecord.getOriginator().getServerName() + " " + logRecord.getSeverity() + " " + logRecord.getMessageId() + " " + logRecord.getMessageText() + "\n   Event Payload: " + logRecord.getAdditionalInformation());
+            }
+            else
+            {
+                System.out.println(logRecord.getTimeStamp() + " " + logRecord.getOriginator().getServerName() + " " + logRecord.getSeverity() + " " + logRecord.getMessageId() + " " + logRecord.getMessageText());
+            }
+        }
+
+        return logRecord.getGUID();
+    }
+}

--- a/event-display-audit-log-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors.auditlog.eventdisplay/EventDisplayAuditLogStoreProvider.java
+++ b/event-display-audit-log-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors.auditlog.eventdisplay/EventDisplayAuditLogStoreProvider.java
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.connectors.auditlog.eventdisplay;
+
+import org.odpi.openmetadata.frameworks.connectors.properties.beans.ConnectorType;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.auditlogstore.OMRSAuditLogStoreProviderBase;
+
+
+/**
+ * EventDisplayAuditLogStoreProvider is the OCF connector provider for the console audit log store.
+ */
+public class EventDisplayAuditLogStoreProvider extends OMRSAuditLogStoreProviderBase
+{
+    /*
+     * Unique identifier for the connector type.
+     */
+    private static final String connectorTypeGUID      = "f986afd0-15d5-4e99-a5fd-35e4a3013da4";
+
+    /*
+     * Descriptive information about the connector for the connector type and audit log.
+     */
+    private static final String connectorQualifiedName = "Egeria:AuditLogDestinationConnector:EventDisplay";
+    private static final String connectorDisplayName   = "Event Display Audit Log Destination Connector";
+    private static final String connectorDescription   = "Connector supports logging of EVENT audit log messages to stdout along with the event payload from the log record's additional information.";
+
+    /*
+     * Class of the connector.
+     */
+    private static final Class<?> connectorClass       = EventDisplayAuditLogStoreConnector.class;
+
+
+    /**
+     * Constructor used to initialize the ConnectorProviderBase with the Java class name of the specific
+     * audit log store implementation.
+     */
+    public EventDisplayAuditLogStoreProvider()
+    {
+        super();
+
+        /*
+         * Set up the class name of the connector that this provider creates.
+         */
+        super.setConnectorClassName(connectorClass.getName());
+
+        /*
+         * Set up the connector type that should be included in a connection used to configure this connector.
+         */
+        ConnectorType connectorType = new ConnectorType();
+        connectorType.setType(ConnectorType.getConnectorTypeType());
+        connectorType.setGUID(connectorTypeGUID);
+        connectorType.setQualifiedName(connectorQualifiedName);
+        connectorType.setDisplayName(connectorDisplayName);
+        connectorType.setDescription(connectorDescription);
+        connectorType.setConnectorProviderClassName(this.getClass().getName());
+        connectorType.setRecognizedConfigurationProperties(super.getRecognizedConfigurationProperties());
+
+        super.connectorTypeBean = connectorType;
+    }
+}
+

--- a/kafka-topics-capture-connector/README.md
+++ b/kafka-topics-capture-connector/README.md
@@ -1,0 +1,15 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+
+# Kafka Topics Capture Connector (kafka-topics-capture-connector)
+
+The *Kafka topics capture connector* is a *Topic Integration Connector* that monitors
+an Apache Kafka server and catalogs the topics that it finds.
+
+This connector allows you to experiment with the behavior of an integration connector.
+
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the Egeria project.

--- a/kafka-topics-capture-connector/pom.xml
+++ b/kafka-topics-capture-connector/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>egeria-dev-projects</artifactId>
+        <groupId>org.odpi.egeria</groupId>
+        <version>3.6-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Kafka Topics Capture Integration Connector</name>
+    <description>
+        Monitors the topics in a Kafka Broker and creates a list of KafkaTopic assets for each topic.
+    </description>
+
+    <artifactId>kafka-topics-capture-connector</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>audit-log-framework</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-connector-framework</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>topic-integrator-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>data-manager-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>repository-services-apis</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <!-- Test framework -->
+
+        <dependency>
+            <groupId>org.odpi.egeria</groupId>
+            <artifactId>open-metadata-ut</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/KafkaTopicsCaptureIntegrationConnector.java
+++ b/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/KafkaTopicsCaptureIntegrationConnector.java
@@ -1,0 +1,306 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+
+package org.odpi.openmetadata.devprojects.connectors.integration.kafka;
+
+
+import org.apache.kafka.clients.admin.Admin;
+import org.odpi.openmetadata.accessservices.datamanager.metadataelements.TopicElement;
+import org.odpi.openmetadata.accessservices.datamanager.properties.TemplateProperties;
+import org.odpi.openmetadata.accessservices.datamanager.properties.TopicProperties;
+import org.odpi.openmetadata.devprojects.connectors.integration.kafka.ffdc.KafkaTopicsCaptureConnectorAuditCode;
+import org.odpi.openmetadata.devprojects.connectors.integration.kafka.ffdc.KafkaTopicsCaptureConnectorErrorCode;
+import org.odpi.openmetadata.frameworks.connectors.ffdc.ConnectorCheckedException;
+import org.odpi.openmetadata.frameworks.connectors.properties.ConnectionProperties;
+import org.odpi.openmetadata.frameworks.connectors.properties.EndpointProperties;
+import org.odpi.openmetadata.integrationservices.topic.connector.TopicIntegratorConnector;
+import org.odpi.openmetadata.integrationservices.topic.connector.TopicIntegratorContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+
+/**
+ * KafkaTopicsCaptureIntegrationConnector catalogues active topics in a kafka broker.
+ */
+public class KafkaTopicsCaptureIntegrationConnector extends TopicIntegratorConnector
+{
+    private String templateQualifiedName = null;
+    private String templateGUID = null;
+    private String targetRootURL = null;
+
+
+    /**
+     * The context provides the integration connector with access to the open metadata ecosystem.
+     */
+    private TopicIntegratorContext myContext = null;
+
+
+    /**
+     * Initialize the connector.
+     *
+     * @param connectorInstanceId - unique id for the connector instance - useful for messages etc
+     * @param connectionProperties - POJO for the configuration used to create the connector.
+     */
+    @Override
+    public void initialize(String connectorInstanceId, ConnectionProperties connectionProperties)
+    {
+        super.initialize(connectorInstanceId, connectionProperties);
+
+        EndpointProperties  endpoint = connectionProperties.getEndpoint();
+
+        if (endpoint != null)
+        {
+            targetRootURL = endpoint.getAddress();
+        }
+
+        Map<String, Object> configurationProperties = connectionProperties.getConfigurationProperties();
+
+        if (configurationProperties != null)
+        {
+            templateQualifiedName = configurationProperties.get(KafkaTopicsCaptureIntegrationProvider.TEMPLATE_QUALIFIED_NAME_CONFIGURATION_PROPERTY).toString();
+        }
+    }
+
+
+    /**
+     * Indicates that the connector is completely configured and can begin processing.
+     * This call can be used to register with non-blocking services.
+     *
+     * @throws ConnectorCheckedException there is a problem within the connector.
+     */
+    @Override
+    public void start() throws ConnectorCheckedException
+    {
+        super.start();
+
+        final String methodName = "start";
+
+        myContext = super.getContext();
+
+        /*
+         * Record the configuration
+         */
+        if (auditLog != null)
+        {
+            auditLog.logMessage(methodName,
+                                KafkaTopicsCaptureConnectorAuditCode.CONNECTOR_CONFIGURATION.getMessageDefinition(connectorName,
+                                                                                                                  targetRootURL,
+                                                                                                                  templateQualifiedName));
+        }
+
+        /*
+         * Retrieve the template if one has been requested
+         */
+        if (templateQualifiedName != null)
+        {
+            try
+            {
+                List<TopicElement> templateElements = myContext.getTopicsByName(templateQualifiedName, 0, 0);
+
+                if (templateElements != null)
+                {
+                    for (TopicElement templateElement : templateElements)
+                    {
+                        String qualifiedName = templateElement.getProperties().getQualifiedName();
+
+                        if (templateQualifiedName.equals(qualifiedName))
+                        {
+                            templateGUID = templateElement.getElementHeader().getGUID();
+                        }
+                    }
+                }
+            }
+            catch (Exception error)
+            {
+                if (auditLog != null)
+                {
+                    auditLog.logException(methodName,
+                                          KafkaTopicsCaptureConnectorAuditCode.MISSING_TEMPLATE.getMessageDefinition(connectorName, templateQualifiedName),
+                                          error);
+                }
+
+            }
+        }
+    }
+
+
+    /**
+     * Requests that the connector does a comparison of the metadata in the third party technology and open metadata repositories.
+     * Refresh is called when the integration connector first starts and then at intervals defined in the connector's configuration
+     * as well as any external REST API calls to explicitly refresh the connector.
+     *
+     * This method performs two sweeps. It first retrieves the topics from the event broker (Kafka) and validates that are in the
+     * catalog - adding or updating them if necessary. The second sweep is to ensure that all of the topics catalogued
+     * actually exist in the event broker.
+     *
+     * @throws ConnectorCheckedException there is a problem with the connector.  It is not able to refresh the metadata.
+     */
+    @Override
+    public void refresh() throws ConnectorCheckedException
+    {
+        final String methodName = "refresh";
+
+        try
+        {
+            /*
+             * Retrieve the list of active topics from Kafka.
+             */
+            Properties properties = new Properties();
+            properties.put("bootstrap.servers", targetRootURL);
+            Admin            admin            = Admin.create(properties);
+            Set<String>      activeTopicNames = admin.listTopics().names().get();
+            admin.close();
+
+            if (activeTopicNames != null)
+            {
+                if (auditLog != null)
+                {
+                    auditLog.logMessage(methodName,
+                                        KafkaTopicsCaptureConnectorAuditCode.RETRIEVED_TOPICS.getMessageDefinition(connectorName,
+                                                                                                                   "localhost:9092",
+                                                                                                                   Integer.toString(activeTopicNames.size())));
+                }
+
+                /*
+                 * Retrieve the topics that are catalogued for this event broker.
+                 * Remove the topics from the catalog that are no longer present in the event broker.
+                 * Remove the names of the topics that are cataloged from the active topic names.
+                 * At the end of this loop, the active topic names will just contain the names of the
+                 * topics that are not catalogued.
+                 */
+                int startFrom = 0;
+                List<TopicElement> cataloguedTopics = myContext.getMyTopics(startFrom, 0);
+
+                while (cataloguedTopics != null)
+                {
+                    startFrom = startFrom + cataloguedTopics.size();
+
+                    for (TopicElement topicElement : cataloguedTopics)
+                    {
+                        String topicName = topicElement.getProperties().getQualifiedName();
+                        String topicGUID = topicElement.getElementHeader().getGUID();
+
+                        if (! activeTopicNames.contains(topicName))
+                        {
+                            /*
+                             * The topic no longer exists so delete it from the catalog.
+                             */
+                            myContext.removeTopic(topicGUID, topicName);
+
+                            if (auditLog != null)
+                            {
+                                auditLog.logMessage(methodName,
+                                                    KafkaTopicsCaptureConnectorAuditCode.TOPIC_DELETED.getMessageDefinition(connectorName,
+                                                                                                                            topicName,
+                                                                                                                            topicGUID));
+                            }
+                        }
+                        else
+                        {
+                            activeTopicNames.remove(topicName);
+                        }
+                    }
+
+                    cataloguedTopics = myContext.getMyTopics(startFrom, 0);
+                }
+
+
+                String topicGUID;
+
+                /*
+                 * Add the remaining active topics to the catalog.
+                 */
+                for (String topicName : activeTopicNames)
+                {
+                    if (templateGUID == null)
+                    {
+                        TopicProperties topicProperties = new TopicProperties();
+
+                        topicProperties.setQualifiedName(topicName);
+                        topicProperties.setTypeName("KafkaTopic");
+
+                        topicGUID = myContext.createTopic(topicProperties);
+
+                        if (topicGUID != null)
+                        {
+                            if (auditLog != null)
+                            {
+                                auditLog.logMessage(methodName,
+                                                    KafkaTopicsCaptureConnectorAuditCode.TOPIC_CREATED.getMessageDefinition(connectorName,
+                                                                                                                            topicName,
+                                                                                                                            topicGUID));
+                            }
+                        }
+                    }
+                    else
+                    {
+                        TemplateProperties templateProperties = new TemplateProperties();
+
+                        templateProperties.setQualifiedName(topicName);
+
+                        topicGUID = myContext.createTopicFromTemplate(templateGUID, templateProperties);
+
+                        if (topicGUID != null)
+                        {
+                            if (auditLog != null)
+                            {
+                                auditLog.logMessage(methodName,
+                                                    KafkaTopicsCaptureConnectorAuditCode.TOPIC_CREATED_FROM_TEMPLATE.getMessageDefinition(connectorName,
+                                                                                                                                          topicName,
+                                                                                                                                          topicGUID,
+                                                                                                                                          templateQualifiedName,
+                                                                                                                                          templateGUID));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception error)
+        {
+            if (auditLog != null)
+            {
+                auditLog.logException(methodName,
+                                      KafkaTopicsCaptureConnectorAuditCode.UNABLE_TO_RETRIEVE_TOPICS.getMessageDefinition(connectorName,
+                                                                                                                          "localhost:9092",
+                                                                                                                          error.getClass().getName(),
+                                                                                                                          error.getMessage()),
+                                      error);
+
+
+            }
+
+            throw new ConnectorCheckedException(KafkaTopicsCaptureConnectorErrorCode.UNEXPECTED_EXCEPTION.getMessageDefinition(connectorName,
+                                                                                                                               error.getClass().getName(),
+                                                                                                                               error.getMessage()),
+                                                this.getClass().getName(),
+                                                methodName,
+                                                error);
+        }
+    }
+
+
+
+    /**
+     * Shutdown kafka monitoring
+     *
+     * @throws ConnectorCheckedException something failed in the super class
+     */
+    @Override
+    public void disconnect() throws ConnectorCheckedException
+    {
+        final String methodName = "disconnect";
+
+
+        if (auditLog != null)
+        {
+            auditLog.logMessage(methodName,
+                                KafkaTopicsCaptureConnectorAuditCode.CONNECTOR_STOPPING.getMessageDefinition(connectorName));
+        }
+
+        super.disconnect();
+    }
+}

--- a/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/KafkaTopicsCaptureIntegrationProvider.java
+++ b/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/KafkaTopicsCaptureIntegrationProvider.java
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+
+package org.odpi.openmetadata.devprojects.connectors.integration.kafka;
+
+import org.odpi.openmetadata.frameworks.auditlog.AuditLogReportingComponent;
+import org.odpi.openmetadata.frameworks.connectors.ConnectorProviderBase;
+import org.odpi.openmetadata.frameworks.connectors.properties.beans.ConnectorType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * KafkaTopicsCaptureIntegrationProvider is the connector provider for the kafka integration connector that extracts topic names from the broker.
+ */
+public class KafkaTopicsCaptureIntegrationProvider extends ConnectorProviderBase
+{
+    /*
+     * Unique identifier of the connector for the audit log.
+     */
+    private static final int    connectorComponentId   = 95;
+
+    /*
+     * Unique identifier for the connector type.
+     */
+    private static final String connectorTypeGUID      = "c8956c71-ead1-49bd-9e38-d7b53a8880c3";
+
+    /*
+     * Descriptive information about the connector for the connector type and audit log.
+     */
+    private static final String connectorQualifiedName = "Egeria:DevProjects:IntegrationConnector:Topics:KafkaTopicsCapture";
+    private static final String connectorDisplayName   = "Kafka Topic Capture Integration Connector";
+    private static final String connectorDescription   = "Connector maintains a list of KafkaTopic assets associated with an Apache Kafka event broker.";
+    private static final String connectorWikiPage      = "https://odpi.github.io/egeria-docs/connectors/integration/kafka-topics-capture-integration-connector/";
+
+    /*
+     * Class of the connector.
+     */
+    private static final Class<?> connectorClass       = KafkaTopicsCaptureIntegrationConnector.class;
+
+
+    static final String TEMPLATE_QUALIFIED_NAME_CONFIGURATION_PROPERTY = "templateQualifiedName";
+
+    /**
+     * Constructor used to initialize the ConnectorProvider with the Java class name of the specific
+     * store implementation.
+     */
+    public KafkaTopicsCaptureIntegrationProvider()
+    {
+        super();
+
+        /*
+         * Set up the class name of the connector that this provider creates.
+         */
+        super.setConnectorClassName(connectorClass.getName());
+
+        /*
+         * Set up the connector type that should be included in a connection used to configure this connector.
+         */
+        ConnectorType connectorType = new ConnectorType();
+        connectorType.setType(ConnectorType.getConnectorTypeType());
+        connectorType.setGUID(connectorTypeGUID);
+        connectorType.setQualifiedName(connectorQualifiedName);
+        connectorType.setDisplayName(connectorDisplayName);
+        connectorType.setDescription(connectorDescription);
+        connectorType.setConnectorProviderClassName(this.getClass().getName());
+        List<String> recognizedConfigurationProperties = new ArrayList<>();
+        recognizedConfigurationProperties.add(TEMPLATE_QUALIFIED_NAME_CONFIGURATION_PROPERTY);
+        connectorType.setRecognizedConfigurationProperties(recognizedConfigurationProperties);
+
+        super.connectorTypeBean = connectorType;
+
+        /*
+         * Set up the component description used in the connector's audit log messages.
+         */
+        AuditLogReportingComponent componentDescription = new AuditLogReportingComponent();
+
+        componentDescription.setComponentId(connectorComponentId);
+        componentDescription.setComponentName(connectorQualifiedName);
+        componentDescription.setComponentDescription(connectorDescription);
+        componentDescription.setComponentWikiURL(connectorWikiPage);
+
+        super.setConnectorComponentDescription(componentDescription);
+
+    }
+}

--- a/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/KafkaTopicsCaptureConnectorAuditCode.java
+++ b/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/KafkaTopicsCaptureConnectorAuditCode.java
@@ -1,0 +1,220 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.connectors.integration.kafka.ffdc;
+
+import org.odpi.openmetadata.frameworks.auditlog.messagesets.AuditLogMessageDefinition;
+import org.odpi.openmetadata.frameworks.auditlog.messagesets.AuditLogMessageSet;
+import org.odpi.openmetadata.repositoryservices.auditlog.OMRSAuditLogRecordSeverity;
+
+
+/**
+ * The KafkaTopicsCaptureConnectorAuditCode is used to define the message content for the OMRS Audit Log.
+ *
+ * The 5 fields in the enum are:
+ * <ul>
+ *     <li>Log Message Id - to uniquely identify the message</li>
+ *     <li>Severity - is this an event, decision, action, error or exception</li>
+ *     <li>Log Message Text - includes placeholder to allow additional values to be captured</li>
+ *     <li>Additional Information - further parameters and data relating to the audit message (optional)</li>
+ *     <li>SystemAction - describes the result of the situation</li>
+ *     <li>UserAction - describes how a user should correct the situation</li>
+ * </ul>
+ */
+public enum KafkaTopicsCaptureConnectorAuditCode implements AuditLogMessageSet
+{
+    CONNECTOR_CONFIGURATION("KAFKA-TOPICS-CAPTURE-CONNECTOR-0001",
+                          OMRSAuditLogRecordSeverity.INFO,
+                          "The {0} integration connector has been initialized to monitor event broker at URL {1} with templateQualifiedName={2}",
+                          "The connector is designed to monitor changes to the topics managed by the event broker.  " +
+                                  "If the templateQualifiedName is set, it identifies a template entity to use.",
+                          "No specific action is required.  This message is to confirm the configuration for the integration connector."),
+
+    BAD_CONFIGURATION("KAFKA-TOPICS-CAPTURE-CONNECTOR-0002",
+                          OMRSAuditLogRecordSeverity.EXCEPTION,
+                          "The {0} integration connector encountered an {1} exception when opening event broker {2} during the {3} method.  The exception message included was {4}",
+                          "The exception is passed back to the Topic Integrator OMIS in the integration daemon that is hosting " +
+                                  "this connector to enable it to perform error handling.  More messages are likely to follow describing the " +
+                                  "error handling that was performed.  These can help to determine how to recover from this error",
+                          "This message contains the exception that was the original cause of the problem. Use the information from the " +
+                                  "exception stack trace to determine why the connector is not able to access the event broker and resolve that issue.  " +
+                                  "Use the messages that where subsequently logged during the error handling to discover how to restart the " +
+                                  "connector in the integration daemon once the original cause of the error has been corrected."),
+
+    BAD_FOLDER_ELEMENT("KAFKA-TOPICS-CAPTURE-CONNECTOR-0003",
+                       OMRSAuditLogRecordSeverity.ERROR,
+                       "The {0} integration connector retrieved an incomplete FileFolder asset for event broker {1}: {2}",
+                       "The metadata element for the event broker that was retrieved from the open metadata repositories has missing " +
+                               "information.  This is likely to be a logic error in the Topic Integrator OMIS or Data Manager OMAS.",
+                       "Look for errors in the audit logs for the integration daemon where the connector and Topic Integrator OMIS are " +
+                               "running and the metadata server where the Data Manager OMAS is running.  Collect these diagnostics and " +
+                               "ask the Egeria community for help to determine why the FileFolder asset is incomplete."),
+
+    UNABLE_TO_RETRIEVE_TOPICS("KAFKA-TOPICS-CAPTURE-CONNECTOR-0004",
+                            OMRSAuditLogRecordSeverity.EXCEPTION,
+                            "The {0} integration connector received an unexpected {2} exception when retrieving topics from event broker at {1}.  The error message was {3}",
+                                     "The exception is returned to the integration daemon that is hosting this connector to enable it to perform error handling.",
+                                     "Use the message in the nested exception to determine the root cause of the error. Once this is " +
+                                             "resolved, follow the instructions in the messages produced by the integration daemon to restart this connector."),
+
+    RETRIEVED_TOPICS("KAFKA-TOPICS-CAPTURE-CONNECTOR-0005",
+                              OMRSAuditLogRecordSeverity.INFO,
+                              "The {0} integration connector has retrieved {2} topics from {1}",
+                              "The connector will maintain these topics as assets.",
+                              "No action is required unless there are errors that follow indicating that the topics can not be maintained."),
+
+    CONNECTOR_STOPPING("KAFKA-TOPICS-CAPTURE-CONNECTOR-0009",
+                                  OMRSAuditLogRecordSeverity.INFO,
+                                  "The {0} integration connector has stopped its topic monitoring and is shutting down",
+                                  "The connector is disconnecting.",
+                                  "No action is required unless there are errors that follow indicating that there were problems shutting down."),
+
+    BAD_TOPIC_ELEMENT("KAFKA-TOPICS-CAPTURE-CONNECTOR-0013",
+                       OMRSAuditLogRecordSeverity.ERROR,
+                       "The {0} integration connector retrieved an incomplete Topic asset: {1}",
+                       "The metadata element for the topic that was retrieved from the open metadata repositories has missing " +
+                               "information.  This is likely to be a logic error in the Topic Integrator OMIS or Data Manager OMAS.",
+                       "Look for errors in the audit logs for the integration daemon where the connector and Topic Integrator OMIS are " +
+                               "running and the metadata server where the Data Manager OMAS is running.  Collect these diagnostics and " +
+                               "ask the Egeria community for help to determine why the Topic element is incomplete."),
+
+    UNEXPECTED_EXC_TOPIC_UPDATE("KAFKA-TOPICS-CAPTURE-CONNECTOR-0014",
+                                 OMRSAuditLogRecordSeverity.EXCEPTION,
+                                 "An unexpected {0} exception was returned to the {1} integration connector when it tried to update the " +
+                                         "Topic in the metadata repositories for topic {2}.  The error message was {3}",
+                                 "The exception is logged and the integration connector continues to synchronize metadata.  " +
+                                         "This topic is not catalogued at this time but may succeed later.",
+                                 "Use the message in the unexpected exception to determine the root cause of the error and fix it."),
+
+    MISSING_TEMPLATE("KAFKA-TOPICS-CAPTURE-CONNECTOR-0015",
+                     OMRSAuditLogRecordSeverity.ERROR,
+                     "The {0} integration connector is unable to retrieve the Topic template with qualified name: {1}",
+                     "The metadata element for the template is not found in the open metadata repositories.  " +
+                             "The template name was configured for the connector.  This means that topics should be catalogued " +
+                             "using the template.  Since the template is missing, topics are not being catalogued.",
+                     "Create the template in the metadata repository.  The connector will catalog the topics during " +
+                             "its next periodic refresh or you can force it to refresh immediately by calling the refresh" +
+                             "operation on the integration daemon."),
+
+    TOPIC_CREATED("KAFKA-TOPICS-CAPTURE-CONNECTOR-0016",
+                      OMRSAuditLogRecordSeverity.INFO,
+                     "The {0} integration connector created the Topic {1} ({2}) for a new real-world topic",
+                     "The connector created the Topic as part of its monitoring of the topics in the event broker.",
+                     "No action is required.  This message is to record the reason why the Topic was created."),
+
+    TOPIC_CREATED_FROM_TEMPLATE("KAFKA-TOPICS-CAPTURE-CONNECTOR-0017",
+                      OMRSAuditLogRecordSeverity.INFO,
+                      "The {0} integration connector created the Topic {1} ({2}) for a new real-world topic using template {3} ({4})",
+                      "The connector created the Topic as part of its monitoring of the topics in the event broker.  " +
+                              "The template provides details of additional metadata that should also be attached to the new Topic element.  " +
+                              "It was specified in the templateQualifiedName configuration property of the connector.",
+                      "No action is required.  This message is to record the reason why the Topic was created with the template."),
+
+    TOPIC_UPDATED("KAFKA-TOPICS-CAPTURE-CONNECTOR-0018",
+                      OMRSAuditLogRecordSeverity.INFO,
+                      "The {0} integration connector has updated the Topic {1} ({2}) because the real-world topic changed",
+                      "The connector updated the Topic as part of its monitoring of the topics in the event broker.",
+                      "No action is required.  This message is to record the reason why the Topic was updated."),
+
+    TOPIC_DELETED("KAFKA-TOPICS-CAPTURE-CONNECTOR-0019",
+                      OMRSAuditLogRecordSeverity.INFO,
+                      "The {0} integration connector has deleted the Topic {1} ({2}) because the real-world topic is no longer defined in the event broker",
+                      "The connector removed the Topic as part of its monitoring of the topics in the event broker.",
+                      "No action is required.  This message is to record the reason why the Topic was removed."),
+
+    TOPIC_ARCHIVED("KAFKA-TOPICS-CAPTURE-CONNECTOR-0020",
+                      OMRSAuditLogRecordSeverity.INFO,
+                      "The {0} integration connector has archived the Topic {1} ({2}) because the real-world topic is no longer stored in the event broker",
+                      "The connector updated the Topic to reflect that is is now just a placeholder for an asset that no longer exists.  " +
+                              "Its presence is still needed in the metadata repository for lineage reporting.",
+                      "No action is required.  This message is to record the reason why the Topic was archived."),
+
+
+    ;
+
+    private String                     logMessageId;
+    private OMRSAuditLogRecordSeverity severity;
+    private String                     logMessage;
+    private String                     systemAction;
+    private String                     userAction;
+
+
+    /**
+     * The constructor for KafkaTopicsCaptureConnectorAuditCode expects to be passed one of the enumeration rows defined in
+     * KafkaTopicsCaptureConnectorAuditCode above.   For example:
+     *
+     *     KafkaTopicsCaptureConnectorAuditCode   auditCode = KafkaTopicsCaptureConnectorAuditCode.SERVER_NOT_AVAILABLE;
+     *
+     * This will expand out to the 4 parameters shown below.
+     *
+     * @param messageId - unique Id for the message
+     * @param severity - severity of the message
+     * @param message - text for the message
+     * @param systemAction - description of the action taken by the system when the condition happened
+     * @param userAction - instructions for resolving the situation, if any
+     */
+    KafkaTopicsCaptureConnectorAuditCode(String                     messageId,
+                                         OMRSAuditLogRecordSeverity severity,
+                                         String                     message,
+                                         String                     systemAction,
+                                         String                     userAction)
+    {
+        this.logMessageId = messageId;
+        this.severity = severity;
+        this.logMessage = message;
+        this.systemAction = systemAction;
+        this.userAction = userAction;
+    }
+
+
+    /**
+     * Retrieve a message definition object for logging.  This method is used when there are no message inserts.
+     *
+     * @return message definition object.
+     */
+    @Override
+    public AuditLogMessageDefinition getMessageDefinition()
+    {
+        return new AuditLogMessageDefinition(logMessageId,
+                                             severity,
+                                             logMessage,
+                                             systemAction,
+                                             userAction);
+    }
+
+
+    /**
+     * Retrieve a message definition object for logging.  This method is used when there are values to be inserted into the message.
+     *
+     * @param params array of parameters (all strings).  They are inserted into the message according to the numbering in the message text.
+     * @return message definition object.
+     */
+    @Override
+    public AuditLogMessageDefinition getMessageDefinition(String ...params)
+    {
+        AuditLogMessageDefinition messageDefinition = new AuditLogMessageDefinition(logMessageId,
+                                                                                    severity,
+                                                                                    logMessage,
+                                                                                    systemAction,
+                                                                                    userAction);
+        messageDefinition.setMessageParameters(params);
+        return messageDefinition;
+    }
+
+
+    /**
+     * JSON-style toString
+     *
+     * @return string of property names and values for this enum
+     */
+    @Override
+    public String toString()
+    {
+        return "KafkaTopicsCaptureConnectorAuditCode{" +
+                "logMessageId='" + logMessageId + '\'' +
+                ", severity=" + severity +
+                ", logMessage='" + logMessage + '\'' +
+                ", systemAction='" + systemAction + '\'' +
+                ", userAction='" + userAction + '\'' +
+                '}';
+    }
+}

--- a/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/KafkaTopicsCaptureConnectorErrorCode.java
+++ b/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/KafkaTopicsCaptureConnectorErrorCode.java
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.connectors.integration.kafka.ffdc;
+
+import org.odpi.openmetadata.frameworks.auditlog.messagesets.ExceptionMessageDefinition;
+import org.odpi.openmetadata.frameworks.auditlog.messagesets.ExceptionMessageSet;
+
+/**
+ * The KafkaTopicsCaptureConnectorErrorCode is used to define first failure data capture (FFDC) for errors that occur when working with
+ * the Kafka monitor integration connector.  It is used in conjunction with both Checked and Runtime (unchecked) exceptions.
+ *
+ * The 5 fields in the enum are:
+ * <ul>
+ *     <li>HTTP Error Code - for translating between REST and JAVA - Typically the numbers used are:</li>
+ *     <li><ul>
+ *         <li>500 - internal error</li>
+ *         <li>400 - invalid parameters</li>
+ *         <li>404 - not found</li>
+ *         <li>409 - data conflict errors - eg item already defined</li>
+ *     </ul></li>
+ *     <li>Error Message Id - to uniquely identify the message</li>
+ *     <li>Error Message Text - includes placeholder to allow additional values to be captured</li>
+ *     <li>SystemAction - describes the result of the error</li>
+ *     <li>UserAction - describes how a consumer should correct the error</li>
+ * </ul>
+ */
+public enum KafkaTopicsCaptureConnectorErrorCode implements ExceptionMessageSet
+{
+    UNEXPECTED_EXCEPTION(500, "KAFKA-TOPICS-CAPTURE-CONNECTOR-500-001",
+             "The {0} integration connector received an unexpected exception {1} when cataloguing topics; the error message was: {2}",
+             "The connector is unable to catalog one or more topics.",
+             "Use the details from the error message to determine the cause of the error and retry the request once it is resolved."),
+    ;
+
+
+    private ExceptionMessageDefinition messageDefinition;
+
+
+    /**
+     * The constructor for KafkaTopicsCaptureConnectorErrorCode expects to be passed one of the enumeration rows defined in
+     * KafkaTopicsCaptureConnectorErrorCode above.   For example:
+     *
+     *     KafkaTopicsCaptureConnectorErrorCode   errorCode = KafkaTopicsCaptureConnectorErrorCode.ERROR_SENDING_EVENT;
+     *
+     * This will expand out to the 5 parameters shown below.
+     *
+     *
+     * @param httpErrorCode   error code to use over REST calls
+     * @param errorMessageId   unique Id for the message
+     * @param errorMessage   text for the message
+     * @param systemAction   description of the action taken by the system when the error condition happened
+     * @param userAction   instructions for resolving the error
+     */
+    KafkaTopicsCaptureConnectorErrorCode(int  httpErrorCode, String errorMessageId, String errorMessage, String systemAction, String userAction)
+    {
+        this.messageDefinition = new ExceptionMessageDefinition(httpErrorCode,
+                                                                errorMessageId,
+                                                                errorMessage,
+                                                                systemAction,
+                                                                userAction);
+    }
+
+
+    /**
+     * Retrieve a message definition object for an exception.  This method is used when there are no message inserts.
+     *
+     * @return message definition object.
+     */
+    @Override
+    public ExceptionMessageDefinition getMessageDefinition()
+    {
+        return messageDefinition;
+    }
+
+
+    /**
+     * Retrieve a message definition object for an exception.  This method is used when there are values to be inserted into the message.
+     *
+     * @param params array of parameters (all strings).  They are inserted into the message according to the numbering in the message text.
+     * @return message definition object.
+     */
+    @Override
+    public ExceptionMessageDefinition getMessageDefinition(String... params)
+    {
+        messageDefinition.setMessageParameters(params);
+
+        return messageDefinition;
+    }
+
+
+    /**
+     * JSON-style toString
+     *
+     * @return string of property names and values for this enum
+     */
+    @Override
+    public String toString()
+    {
+        return "KafkaTopicsCaptureConnectorErrorCode{" +
+                       "messageDefinition=" + messageDefinition +
+                       '}';
+    }
+}

--- a/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/package-info.java
+++ b/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/package-info.java
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+/**
+ * FFDC stands for First Failure Data Capture.  The classes in this package provide the message definitions and
+ * descriptions used by the kafka monitor integration connector.  KafkaTopicsCaptureConnectorAuditCode contains the
+ * messages for the audit log and the KafkaTopicsCaptureConnectorErrorCode contains the messages for any exceptions
+ * that are thrown by the connectors.
+ */
+package org.odpi.openmetadata.devprojects.connectors.integration.kafka.ffdc;

--- a/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/package-info.java
+++ b/kafka-topics-capture-connector/src/main/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/package-info.java
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: Apache 2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+/**
+ * The kafka monitor integration connector catalogues active topics in an Apache Kafka event broker.
+ */
+package org.odpi.openmetadata.devprojects.connectors.integration.kafka;

--- a/kafka-topics-capture-connector/src/test/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/AuditCodeTest.java
+++ b/kafka-topics-capture-connector/src/test/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/AuditCodeTest.java
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.connectors.integration.kafka.ffdc;
+
+import org.odpi.openmetadata.test.unittest.utilities.AuditLogMessageSetTest;
+import org.testng.annotations.Test;
+
+
+/**
+ * Verify the KafkaTopicsCaptureConnectorAuditCode enum contains unique message ids, non-null names and descriptions and can be
+ * serialized to JSON and back again.
+ */
+public class AuditCodeTest extends AuditLogMessageSetTest
+{
+    final static String  messageIdPrefix = "KAFKA-TOPICS-CAPTURE-CONNECTOR";
+
+    /**
+     * Validated the values of the enum.
+     */
+    @Test public void testAllAuditCodeValues()
+    {
+        for (KafkaTopicsCaptureConnectorAuditCode errorCode : KafkaTopicsCaptureConnectorAuditCode.values())
+        {
+            super.testSingleAuditCodeValue(errorCode, messageIdPrefix);
+        }
+    }
+}

--- a/kafka-topics-capture-connector/src/test/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/ErrorCodeTest.java
+++ b/kafka-topics-capture-connector/src/test/java/org/odpi/openmetadata/devprojects/connectors/integration/kafka/ffdc/ErrorCodeTest.java
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the ODPi Egeria project. */
+package org.odpi.openmetadata.devprojects.connectors.integration.kafka.ffdc;
+
+import org.odpi.openmetadata.test.unittest.utilities.ExceptionMessageSetTest;
+import org.testng.annotations.Test;
+
+
+/**
+ * Verify the KafkaTopicsCaptureConnectorErrorCode enum contains unique message ids, non-null names and descriptions and can be
+ * serialized to JSON and back again.
+ */
+public class ErrorCodeTest extends ExceptionMessageSetTest
+{
+    final static String  messageIdPrefix = "KAFKA-TOPICS-CAPTURE-CONNECTOR";
+
+    /**
+     * Validated the values of the enum.
+     */
+    @Test public void testAllErrorCodeValues()
+    {
+        for (KafkaTopicsCaptureConnectorErrorCode errorCode : KafkaTopicsCaptureConnectorErrorCode.values())
+        {
+            super.testSingleErrorCodeValue(errorCode, messageIdPrefix);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,1244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <scm>
+        <connection>scm:git:git://github.com/odpi/egeria-dev-projects.git</connection>
+        <developerConnection>scm:git:ssh://github.com/odpi/egeria-dev-projects.git</developerConnection>
+        <url>http://github.com/odpi/egeria-dev-projects</url>
+    </scm>
+
+    <name>Egeria Developer Projects</name>
+    <description>
+        Top-level package for the dev projects to allow a single build of the java code.
+    </description>
+
+    <groupId>org.odpi.egeria</groupId>
+    <artifactId>egeria-dev-projects</artifactId>
+    <version>3.6-SNAPSHOT</version>
+
+    <url>https://egeria-project.org/</url>
+
+    <!-- The Apache license is used for code and the creative commons license is used for documentation -->
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+        <license>
+            <name>Creative Commons Attribution 4.0 International (CC BY 4.0)</name>
+            <url>https://creativecommons.org/licenses/by/4.0</url>
+        </license>
+    </licenses>
+
+    <organization>
+        <name>LF AI &amp; Data Foundation</name>
+        <url>https://lfaidata.foundation/</url>
+    </organization>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/odpi/egeria-dev-projects/issues</url>
+    </issueManagement>
+
+    <inceptionYear>2018</inceptionYear>
+
+    <mailingLists>
+        <mailingList>
+            <name>odpi-egeria</name>
+            <subscribe>egeria-technical-discuss+subscribe@lists.lfaidata.foundation</subscribe>
+            <unsubscribe>egeria-technical-discuss+unsubscribe@lists.lfaidata.foundation</unsubscribe>
+            <archive>https://lists.lfaidata.foundation/g/egeria-technical-discuss/topics</archive>
+            <post>egeria-technical-discuss@lists.lfaidata.foundation</post>
+        </mailingList>
+    </mailingLists>
+
+    <developers>
+        <developer>
+            <id>mandy-chessell</id>
+            <name>Mandy Chessell</name>
+            <email>mandy.e.chessell@gmail.com</email>
+            <timezone>Europe/London</timezone>
+            <roles>
+                <role>Project Leader</role>
+                <role>maintainer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>planetf1</id>
+            <name>Nigel Jones</name>
+            <email>nigel.l.jones+git@gmail.com</email>
+            <timezone>Europe/London</timezone>
+            <roles>
+                <role>maintainer</role>
+            </roles>
+            <organization>IBM Corporation</organization>
+        </developer>
+    </developers>
+
+    <!-- POM packaging means that this module has sub-modules -->
+    <packaging>pom</packaging>
+
+    <repositories>
+        <repository>
+            <id>1-MavenCentral</id>
+            <url>https://repo1.maven.org/maven2/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <!-- Needed for fixes to old jackson libraries used as transitive dependencies -->
+        <repository>
+            <id>2-Fixes</id>
+            <url>https://maven.atlassian.com/3rdparty/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>1-MavenCentral</id>
+            <url>https://repo1.maven.org/maven2/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
+
+    <modules>
+        <module>egeria-report-utilities</module>
+        <module>component-id-report</module>
+        <module>egeria-config-utility</module>
+        <module>egeria-ops-utility</module>
+        <module>egeria-platform-report</module>
+        <module>event-display-audit-log-connector</module>
+        <module>kafka-topics-capture-connector</module>
+        <module>asset-look-up</module>
+        <module>asset-set-up</module>
+    </modules>
+
+
+    <properties>
+        <open-metadata.version>3.6-SNAPSHOT</open-metadata.version>
+
+        <!-- Level of Java  -->
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <!-- Platform encoding  -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <classmate.version>1.5.1</classmate.version>
+
+        <!-- Versions of dependent libraries -->
+
+        <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
+        <testng.version>7.4.0</testng.version>
+        <logback.version>1.2.10</logback.version>
+        <kafka.version>3.0.0</kafka.version>
+
+        <!-- Versions of plugins -->
+        <enunciate-maven-plugin.version>2.10.1</enunciate-maven-plugin.version>
+        <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
+        <maven-reports-plugin.version>3.1.2</maven-reports-plugin.version>
+        <maven-site-plugin.version>3.10.0</maven-site-plugin.version>
+        <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+        <maven-shade.version>3.2.4</maven-shade.version>
+        <maven-install.version>3.0.0-M1</maven-install.version>
+        <maven-compiler.version>3.8.1</maven-compiler.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+        <owasp.version>6.5.2</owasp.version>
+        <maven-pmd.version>3.15.0</maven-pmd.version>
+        <spotbugs-maven.version>4.5.2.0</spotbugs-maven.version>
+        <maven-download.version>1.6.7</maven-download.version>
+        <maven-antrun.version>3.0.0</maven-antrun.version>
+        <spotify-docker-plugin.version>1.4.13</spotify-docker-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+        <jacoco-plugin.version>0.8.7</jacoco-plugin.version>
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+        <frontend.plugin.version>1.12.1</frontend.plugin.version>
+        <exec.plugin.version>3.0.0</exec.plugin.version>
+        <resources.plugin.version>3.2.0</resources.plugin.version>
+        <rat-plugin.version>0.13</rat-plugin.version>
+        <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
+        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
+        <nexus-staging-maven-plugin>1.6.8</nexus-staging-maven-plugin>
+        <license-plugin.version>2.0.0</license-plugin.version>
+        <build-helper.version>3.2.0</build-helper.version>
+        <failsafe-plugin.version>3.0.0-M5</failsafe-plugin.version>
+        <git-commit-plugin.version>4.9.10</git-commit-plugin.version>
+        <process-exec-plugin.version>0.9</process-exec-plugin.version>
+        <groovy-plugin.version>2.1.1</groovy-plugin.version>
+        <properties.plugin.version>1.0.0</properties.plugin.version>
+        <openlineage.version>0.4.0</openlineage.version>
+
+        <!-- Configuration of sonar code scanning-->
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <!--suppress UnresolvedMavenProperty -->
+        <sonar.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/target/jacoco.xml
+        </sonar.jacoco.xmlReportPaths>
+        <!-- Sonar configuration - exclusions to all processing, coverage only exclusions, and duplicate exclusions -->
+        <!-- fvt skipped as it causes resource limits to be exceeded. generated code contaminates stats so removed  -->
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <sonar.coverage.exclusions>**/generated/**</sonar.coverage.exclusions>
+        <sonar.cpd.exclusions>**/generated/**</sonar.cpd.exclusions>
+
+    </properties>
+
+    <dependencyManagement>
+
+        <dependencies>
+
+            <!-- ============================================= -->
+            <!-- Local git repository dependencies -->
+
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>egeria-report-utilities</artifactId>
+                <scope>compile</scope>
+                <version>${project.version}</version>
+            </dependency>
+
+
+            <!-- ============================================= -->
+            <!-- External project dependencies used at runtime -->
+
+            <!-- Add this dependency to your pom file and the logback.xml to its resources
+                 directory to provide a default log destination for SLF4J -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <scope>compile</scope>
+                <version>${logback.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <scope>compile</scope>
+                <version>${logback.version}</version>
+            </dependency>
+
+            <!-- Kafka is used explicitly in the kafka topics capture connector -->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <scope>compile</scope>
+                <version>${kafka.version}</version>
+            </dependency>
+
+            <!-- ================================ -->
+            <!-- Egeria libraries used at runtime -->
+
+
+            <!-- Error handling and audit logging -->
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>audit-log-framework</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>ffdc-services</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <!-- Writing connectors -->
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>open-connector-framework</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>topic-integrator-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <!-- APIs for configuring the OMAG Server Platform and its servers,
+                 controlling them once deployed and querying their status -->
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>admin-services-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>admin-services-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>repository-services-apis</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>repository-services-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>integration-daemon-services-registration</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>platform-services-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>platform-services-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <!-- Connector implementations used in the platform report -->
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>cohort-registry-file-store-connector</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>open-metadata-archive-file-connector</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>open-metadata-archive-directory-connector</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>inmemory-repository-connector</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>omrs-rest-repository-connector</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>open-metadata-security-samples</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <!-- Open metadata and governance interfaces used in the management of the asset metadata -->
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>asset-consumer-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>asset-consumer-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>asset-owner-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>asset-owner-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>asset-manager-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>asset-manager-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>data-manager-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>data-manager-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>digital-architecture-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>digital-architecture-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>governance-program-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>governance-program-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>it-infrastructure-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>it-infrastructure-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>subject-area-api</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>subject-area-client</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <!-- Turns off certificate checking -->
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>http-helper</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <!-- Test framework -->
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>open-metadata-ut</artifactId>
+                <scope>compile</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <scope>test</scope>
+                <version>${testng.version}</version>
+            </dependency>
+
+        </dependencies>
+
+    </dependencyManagement>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <build>
+
+        <pluginManagement>
+
+            <plugins>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>dockerfile-maven-plugin</artifactId>
+                    <version>${spotify-docker-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${maven-assembly-plugin.version}</version>
+                    <configuration>
+                        <tarLongFileMode>posix</tarLongFileMode>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <version>${maven-download.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>${maven-antrun.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <version>${frontend.plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <version>${exec.plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${resources.plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${maven-shade.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.rat</groupId>
+                    <artifactId>apache-rat-plugin</artifactId>
+                    <version>${rat-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>${license-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
+                </plugin>
+
+                <!-- Dependency stack for testing used in some modules -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.plugin.version}</version>
+                    <configuration>
+                        <forkCount>3</forkCount>
+                        <reuseForks>true</reuseForks>
+                        <!--suppress UnresolvedMavenProperty -->
+                        <argLine>-Xmx1024m ${argLine}</argLine>
+                        <systemPropertyVariables>
+                            <org.slf4j.simpleLogger.defaultLogLevel>INFO</org.slf4j.simpleLogger.defaultLogLevel>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven-javadoc-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>${maven-reports-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>${maven-site-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>${owasp.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${spotbugs-maven.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>${maven-pmd.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${maven-gpg-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${nexus-staging-maven-plugin}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>${git-commit-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.springdoc</groupId>
+                    <artifactId>springdoc-openapi-maven-plugin</artifactId>
+                    <version>${springdoc-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${build-helper.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${failsafe-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.bazaarvoice.maven.plugins</groupId>
+                    <artifactId>process-exec-maven-plugin</artifactId>
+                    <version>${process-exec-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.gmaven</groupId>
+                    <artifactId>groovy-maven-plugin</artifactId>
+                    <version>${groovy-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>properties-maven-plugin</artifactId>
+                    <version>${properties.plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok-maven-plugin</artifactId>
+                    <version>${lombok-plugin.version}</version>
+                </plugin>
+
+            </plugins>
+
+        </pluginManagement>
+
+        <!-- Should be default, but needed to keep IntelliJ happy -->
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
+
+        <!-- Default compiler options - enable additional lint checks -->
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-Xlint:all</compilerArgument>
+                    <failOnWarning>false</failOnWarning>
+                </configuration>
+            </plugin>
+
+            <!-- Use surefire for unit tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+            <!-- Validates maven & java versions -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>display-info</id>
+                        <goals>
+                            <goal>display-info</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.5.0,)</version>
+                                    <message>** MAVEN VERSION ERROR ** Maven 3.5.0 or above is required. See
+                                        https://maven.apache.org/install.html
+                                    </message>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <level>ERROR</level>
+                                    <version>[11,)</version>
+                                    <message>** JAVA VERSION ERROR ** Java 11 or above is required.
+                                    </message>
+                                </requireJavaVersion>
+                                <banDuplicatePomDependencyVersions/>
+                                <requireSameVersions/>
+                                <reactorModuleConvergence/>
+				                <requireUpperBoundDeps>
+                                    <excludes>
+				                           <!-- Required as the ui chassis pulls in dependencies using older, but later versioned beta code -->
+                                        <exclude>org.slf4j:slf4j-api</exclude>
+                                    </excludes>
+                                </requireUpperBoundDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <useDefaultExcludes>true</useDefaultExcludes>
+                    <useMavenDefaultExcludes>true</useMavenDefaultExcludes>
+                    <useIdeaDefaultExcludes>true</useIdeaDefaultExcludes>
+                    <useEclipseDefaultExcludes>true</useEclipseDefaultExcludes>
+                    <excludeSubProjects>true</excludeSubProjects>
+                    <excludes>
+                        <exclude>/CNAME</exclude>
+                        <exclude>/dco-signoffs/*.txt</exclude>
+                        <exclude>**/banner.txt</exclude>
+                        <exclude>**/*.txt</exclude>
+                        <exclude>**/*.json</exclude>
+                        <exclude>**/*.patch</exclude>
+                        <exclude>**/*.drawio</exclude>
+                        <exclude>**/*.log</exclude>
+                        <exclude>**/*.csv</exclude>
+                        <exclude>**/*.ipynb</exclude>
+                        <exclude>**/*.png</exclude>
+                        <exclude>**/*.svg</exclude>
+                        <exclude>**/*.iml</exclude>
+                        <exclude>**/*.registrystore</exclude>
+                        <exclude>**/*.results</exclude>
+                        <exclude>**/*.graphml</exclude>
+                        <exclude>**/*.isx</exclude>
+                        <exclude>**/target/**</exclude>
+                        <exclude>**/build/**</exclude>
+                        <exclude>**/venv/**</exclude>
+                        <exclude>**/.repository/**</exclude>
+                        <exclude>gradle/wrapper/**</exclude>
+                        <exclude>**/log</exclude>
+                        <exclude>**/*.lock</exclude>
+                        <exclude>**/m2repo*/**</exclude>
+                        <exclude>**/venv/**</exclude>
+                        <exclude>**/archives/patches/egeria.patch</exclude>
+                        <exclude>**/docs/**/*.xml</exclude>
+                        <exclude>**/docs/**/*.svg</exclude>
+                        <exclude>**/website/**/*.xml</exclude>
+                        <exclude>**/dependency-reduced-pom.xml</exclude>
+                        <exclude>**/.classpath</exclude>
+                        <exclude>**/.project</exclude>
+                        <exclude>**/.settings/**</exclude>
+                        <exclude>*-graph-repositories/**</exclude>
+                        <exclude>**/.vscode*/**</exclude>
+                        <exclude>**/.factorypath/**</exclude>
+                        <exclude>**/**.code-workspace</exclude>
+                        <exclude>config</exclude>
+                        <exclude>**/LICENSE*.txt</exclude>
+                        <exclude>data/**</exclude>
+                        <exclude>**/certificates/**</exclude>
+                        <exclude>**/*.p12</exclude>
+                        <exclude>**/*.crt</exclude>
+                        <exclude>**/*.key</exclude>
+                    </excludes>
+                    <licenseFamilies>
+                        <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
+                            <familyName>SPDX-License-Identifier: Apache-2.0</familyName>
+                        </licenseFamily>
+                        <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
+                            <familyName>SPDX-License-Identifier: CC-BY-4.0</familyName>
+                        </licenseFamily>
+                    </licenseFamilies>
+                    <licenses>
+                        <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+                            <licenseFamilyCategory>SPDX</licenseFamilyCategory>
+                            <licenseFamilyName>SPDX-License-Identifier: Apache-2.0</licenseFamilyName>
+                            <notes></notes>
+                            <patterns>
+                                <pattern>SPDX-License-Identifier: Apache-2.0</pattern>
+                            </patterns>
+                        </license>
+                        <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+                            <licenseFamilyCategory>SPDX</licenseFamilyCategory>
+                            <licenseFamilyName>SPDX-License-Identifier: CC-BY-4.0</licenseFamilyName>
+                            <notes></notes>
+                            <patterns>
+                                <pattern>SPDX-License-Identifier: CC-BY-4.0</pattern>
+                            </patterns>
+                        </license>
+                        <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+                            <patterns>
+                                <pattern>Copyright Contributors to the ODPi Egeria project.</pattern>
+                            </patterns>
+                        </license>
+                    </licenses>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>rat-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Sonar-JaCoCo integration plugin -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Check no unnecessary or missing dependencies           -->
+            <!-- Note test scope dependencies can't be reliably checked -->
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <outputXML>true</outputXML>
+                            <ignoredUnusedDeclaredDependencies>
+                                <!-- Test dependencies - should only be used in test scope. False positive from dependency check -->
+                                <ignoredUnusedDeclaredDependency>org.junit.jupiter:*</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.mockito:*</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.testng:*</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>junit:*</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-actuator</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>io.micrometer:*</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.junit.platform:*</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:*</ignoredUnusedDeclaredDependency>
+                                <!-- Used with slf4j as default implementation in test scope only -->
+                                <ignoredUnusedDeclaredDependency>ch.qos.logback:logback*:*
+                                </ignoredUnusedDeclaredDependency>
+                                <!-- Used with slf4j as default implementation for chassis & apps (more configurable in xml)-->
+                                <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple:*
+                                </ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>depmgmt</id>
+                        <goals>
+                            <goal>analyze-dep-mgt</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <failBuild>true</failBuild>
+                            <ignoreDirect>true</ignoreDirect>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalJOption>-J-Xmx1536m</additionalJOption>
+                    <quiet>true</quiet>
+                    <sourcepath>${project.build.directory}/delombok</sourcepath>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- always create empty javadoc and source jars for every project           -->
+            <!-- Needed for Maven central release process for all components of type jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>createemptydocsource</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <touch file="${project.build.directory}/${project.artifactId}-${project.version}-sources.jar"/>
+                                <touch file="${project.build.directory}/${project.artifactId}-${project.version}-javadoc.jar"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <id>aggregate</id>
+                        <inherited>false</inherited>
+                        <reports>
+                            <report>aggregate</report>
+                        </reports>
+                    </reportSet>
+                    <reportSet>
+                        <id>default</id>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+
+    <profiles>
+
+        <profile>
+            <id>owasp</id>
+            <activation>
+                <property>
+                    <name>CVE</name>
+                </property>
+            </activation>
+            <!-- Build reports - findBugs security checks -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <configuration>
+                            <skipSystemScope>true</skipSystemScope>
+                            <skipProvidedScope>true</skipProvidedScope>
+                            <skipTestScope>true</skipTestScope>
+                            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                            <enableExperimental>true</enableExperimental>
+                            <rubygemsAnalyzerEnabled>false</rubygemsAnalyzerEnabled>
+                            <cmakeAnalyzerEnabled>false</cmakeAnalyzerEnabled>
+                            <autoconfAnalyzerEnabled>false</autoconfAnalyzerEnabled>
+                            <nodeAnalyzerEnabled>true</nodeAnalyzerEnabled>
+                            <cocoapodsAnalyzerEnabled>false</cocoapodsAnalyzerEnabled>
+                            <bundleAuditAnalyzerEnabled>false</bundleAuditAnalyzerEnabled>
+                            <swiftPackageManagerAnalyzerEnabled>false</swiftPackageManagerAnalyzerEnabled>
+                            <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
+                            <nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
+                            <retireJsAnalyzerEnabled>true</retireJsAnalyzerEnabled>
+                        </configuration>
+                        <executions>
+
+                            <execution>
+                                <id>full-cve</id>
+                                <inherited>false</inherited>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>artifactory</id>
+            <distributionManagement>
+                <repository>
+                    <id>central</id>
+                    <name>odpi-artifactory-primary-0-staging</name>
+                    <url>https://odpi.jfrog.io/odpi/egeria-staging</url>
+                </repository>
+                <snapshotRepository>
+                    <id>snapshots</id>
+                    <name>odpi-artifactory-primary-0-snapshots</name>
+                    <url>https://odpi.jfrog.io/odpi/egeria-snapshot</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+
+        <profile>
+            <id>dist-github</id>
+            <activation>
+                <property>
+                    <name>useGitHub</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <distributionManagement>
+                <repository>
+                    <id>github</id>
+                    <name>GitHub Packages</name>
+                    <url>https://maven.pkg.github.com/odpi/egeria</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+        <profile>
+            <id>dist-oss</id>
+            <activation>
+                <property>
+                    <name>useMavenCentral</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <distributionManagement>
+                <repository>
+                    <id>ossrh</id>
+                    <name>Central Repository OSSRH - Staging</name>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+                  </repository>
+                  <snapshotRepository>
+                    <id>ossrh</id>
+                    <name>Central Repository OSSRH - Snapshots</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                  </snapshotRepository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <!--suppress MavenModelInspection -->
+                                    <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+                                    <gpgArguments>
+                                        <arg>--batch</arg>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- Warning - skips most checks, but does a quick(er) compile for quick turnaround time -->
+        <profile>
+            <id>quick</id>
+            <activation>
+                <property>
+                    <name>quick</name>
+                </property>
+            </activation>
+            <properties>
+                <rat.skip>true</rat.skip>
+                <skipTests>true</skipTests>
+                <skipFVT>true</skipFVT>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <maven.source.skip>true</maven.source.skip>
+                <enforcer.skip>true</enforcer.skip>
+                <jacoco.skip>true</jacoco.skip>
+            </properties>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
Signed-off-by: Mandy Chessell <mandy.e.chessell@gmail.com>

This pull request has a set of utilities and connectors that are for the developer dojo.  The purpose of this PR is to make them visible to a broader audience. 

The following are reasonably complete:
- component-id-report - list component ids in use by Egeria
- egeria-config-utility - simple configuration capability
- egeria-ops-utility - start/stop servers utility
- egeria-report-utilities - shared library used by reporting utilities
- event-display-audit-log-connector - connector to display event payloags in the console audit log
- kafka-topics-capture-connector - connector to catalog topics running in Kafka

The asset-set-up and asset-look-up modules are just skeleton modules.

There is a corresponding set of fixes to egeria that are needed to allow the utilities to run successfully.